### PR TITLE
Specify opengl es version in androidmanifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.mapzen.erasermap">
 
+    <uses-feature android:glEsVersion="0x00020000" android:required="true" />
+
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />


### PR DESCRIPTION
- Based on the documentation we need to specify opengles version in the manifest else its defined to pick 1.0 as the
default!

http://developer.android.com/guide/topics/manifest/uses-feature-element.html#glEsVersion