### PR TITLE
Maintain route state on rotation

### DIFF
--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -7,6 +7,9 @@ import com.mapzen.erasermap.model.RouterFactory;
 import com.mapzen.erasermap.model.ValhallaRouterFactory;
 import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
+import com.mapzen.erasermap.presenter.RoutePresenter;
+import com.mapzen.erasermap.presenter.RoutePresenterImpl;
+import com.mapzen.helpers.RouteEngine;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -48,6 +51,10 @@ public class AndroidModule {
     @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation,
             RouterFactory routerFactory) {
         return new MainPresenterImpl(mapzenLocation, routerFactory);
+    }
+
+    @Provides @Singleton RoutePresenter provideRoutePresenter(RouteEngine routeEngine) {
+        return new RoutePresenterImpl(routeEngine);
     }
 
     @Provides @Singleton RouterFactory provideRouterFactory() {

--- a/app/src/main/java/com/mapzen/erasermap/CommonModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/CommonModule.java
@@ -20,7 +20,7 @@ public class CommonModule {
         return new Bus();
     }
 
-    @Provides RouteEngine provideRouteEngine() {
+    @Provides @Singleton RouteEngine provideRouteEngine() {
         return new RouteEngine();
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -23,8 +23,8 @@ import java.util.ArrayList
 public open class MainPresenterImpl(val mapzenLocation: MapzenLocation,
         val routerFactory: RouterFactory) : MainPresenter, RouteCallback {
 
-    override var currentFeature: Feature? = null;
-    override var route: Route? = null;
+    override var currentFeature: Feature? = null
+    override var route: Route? = null
     override var routingEnabled : Boolean = false
     override var mainViewController: MainViewController? = null
     override var routeViewController: RouteViewController? = null

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
@@ -1,0 +1,11 @@
+package com.mapzen.erasermap.presenter
+
+import android.location.Location
+import com.mapzen.helpers.RouteListener
+import com.mapzen.valhalla.Route
+
+public interface RoutePresenter {
+    public var routeListener: RouteListener?
+    public fun onLocationChanged(location: Location)
+    public fun setRoute(route: Route?)
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -1,0 +1,23 @@
+package com.mapzen.erasermap.presenter
+
+import android.location.Location
+import com.mapzen.helpers.RouteEngine
+import com.mapzen.helpers.RouteListener
+import com.mapzen.valhalla.Route
+
+public class RoutePresenterImpl(val routeEngine: RouteEngine) : RoutePresenter {
+    override var routeListener: RouteListener? = null
+        set(value) {
+            routeEngine.setListener(value)
+        }
+
+    override fun onLocationChanged(location: Location) {
+        routeEngine.onLocationChanged(location)
+    }
+
+    override fun setRoute(route: Route?) {
+        if (routeEngine.getRoute() == null) {
+            routeEngine.setRoute(route)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -608,16 +608,10 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         findViewById(R.id.route_mode).setVisibility(View.VISIBLE)
         (findViewById(R.id.route_mode) as RouteModeView).presenter = presenter
         presenter?.routeViewController = findViewById(R.id.route_mode) as RouteModeView
-
-        if(presenter?.route == null) {
-            route()
-        } else {
-            this.route = presenter?.route
-        }
-
+        this.route = presenter?.route
         val pager = findViewById(R.id.route_mode) as RouteModeView
         pager.route = this.route
-        pager.routeEngine?.setRoute(route)
+        pager.routePresenter?.setRoute(route)
         pager.voiceNavigationController = VoiceNavigationController(this)
 
         val instructions = route?.getRouteInstructions()

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -17,6 +17,7 @@ import android.widget.TextView
 import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
 import com.mapzen.erasermap.presenter.MainPresenter
+import com.mapzen.erasermap.presenter.RoutePresenter
 import com.mapzen.erasermap.util.DisplayHelper
 import com.mapzen.helpers.RouteEngine
 import com.mapzen.helpers.RouteListener
@@ -37,11 +38,11 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
     var route: Route? = null
     var slideLayout: SlidingUpPanelLayout? = null
     var panelListener: SlidingUpPanelLayout.PanelSlideListener? = null
-    var routeEngine: RouteEngine? = null
-        @Inject set
     var routeListener: RouteModeListener = RouteModeListener()
     var presenter: MainPresenter? = null
     var voiceNavigationController: VoiceNavigationController? = null
+    var routePresenter: RoutePresenter? = null
+        @Inject set
 
     private var currentInstructionIndex: Int = 0
 
@@ -62,7 +63,7 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
         (context.getApplicationContext() as EraserMapApplication).component()?.inject(this)
         (getContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater)
                 .inflate(R.layout.view_route_mode, this, true)
-        routeEngine?.setListener(routeListener)
+        routePresenter?.routeListener = routeListener
         (findViewById(R.id.resume) as ImageButton).setOnClickListener {
             presenter?.onResumeRouting()
             pager?.setCurrentItem(currentInstructionIndex)
@@ -279,8 +280,10 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
 
         override fun onInstructionComplete(index: Int) {
             log("[onInstructionComplete]", index)
-            val icon = findViewByIndex(index)?.findViewById(R.id.icon) as ImageView
-            icon.setImageResource(DisplayHelper.getRouteDrawable(getContext(), 8))
+            val icon = findViewByIndex(index)?.findViewById(R.id.icon)
+            if (icon is ImageView) {
+                icon.setImageResource(DisplayHelper.getRouteDrawable(getContext(), 8))
+            }
             val instruction = route?.getRouteInstructions()?.get(index)
             if (instruction is Instruction) voiceNavigationController?.playPost(instruction)
         }
@@ -330,7 +333,7 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
 
     override fun onLocationChanged(location: Location) {
         if (route != null) {
-            routeEngine?.onLocationChanged(location)
+            routePresenter?.onLocationChanged(location)
         }
     }
 }

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -7,6 +7,9 @@ import com.mapzen.erasermap.model.RouterFactory;
 import com.mapzen.erasermap.model.TestRouterFactory;
 import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
+import com.mapzen.erasermap.presenter.RoutePresenter;
+import com.mapzen.erasermap.presenter.RoutePresenterImpl;
+import com.mapzen.helpers.RouteEngine;
 
 import org.mockito.Mockito;
 
@@ -50,6 +53,10 @@ public class TestAndroidModule {
     @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation,
             RouterFactory routerFactory) {
         return new MainPresenterImpl(mapzenLocation, routerFactory);
+    }
+
+    @Provides @Singleton RoutePresenter provideRoutePresenter(RouteEngine routeEngine) {
+        return new RoutePresenterImpl(routeEngine);
     }
 
     @Provides @Singleton RouterFactory provideRouterFactory() {

--- a/app/src/test/java/com/mapzen/erasermap/view/RouteModeViewTest.java
+++ b/app/src/test/java/com/mapzen/erasermap/view/RouteModeViewTest.java
@@ -238,8 +238,8 @@ public class RouteModeViewTest {
     }
 
     @Test
-    public void shouldInjectRouteEngine() throws Exception {
-        assertThat(routeModeView.getRouteEngine()).isNotNull();
+    public void shouldInjectRoutePresenter() throws Exception {
+        assertThat(routeModeView.getRoutePresenter()).isNotNull();
     }
 
     @Test

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -86,6 +86,16 @@ public class MainPresenterTest {
     }
 
     @Test
+    public fun onRestoreViewState_shouldShowRoutingMode() {
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        val newController = TestMainController()
+        presenter.mainViewController = newController
+        presenter.routingEnabled = true
+        presenter.onRestoreViewState()
+        assertThat(newController.isRoutingModeVisible).isTrue()
+    }
+
+    @Test
     public fun onCollapseSearchView_shouldHideSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -1,0 +1,26 @@
+package com.mapzen.erasermap.presenter
+
+import com.mapzen.erasermap.dummy.TestHelper.getFixture
+import com.mapzen.helpers.RouteEngine
+import com.mapzen.valhalla.Route
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+public class RoutePresenterTest {
+    private val routeEngine = RouteEngine()
+    private val routePresenter = RoutePresenterImpl(routeEngine)
+
+    @Test
+    public fun shouldNotBeNull() {
+        assertThat(routePresenter).isNotNull()
+    }
+
+    @Test
+    public fun setRoute_shouldNotResetRouteEngineWhileRouting() {
+        val route1 = Route(getFixture("valhalla_route"))
+        val route2 = Route(getFixture("valhalla_route"))
+        routeEngine.setRoute(route1)
+        routePresenter.setRoute(route2)
+        assertThat(routeEngine.getRoute()).isEqualTo(route1)
+    }
+}


### PR DESCRIPTION
Prevents replay of completed instructions when rotating the device during routing.

* Make RouteEngine a singleton
* Extracts RoutePresenter
* Do not reset RouteEngine if already routing
* Verify icon is ImageView to prevent type cast error