### PR TITLE
Update scene yaml

### DIFF
--- a/app/src/main/assets/scene.yaml
+++ b/app/src/main/assets/scene.yaml
@@ -1,3 +1,6 @@
+scene:
+    background:
+        color: '#8db7d5'
 cameras:
     camera1:
         type: perspective #currently ignored
@@ -32,12 +35,21 @@ textures:
             bookstore: [0, 333, 32, 32]
 
 styles:
+    flatcolor:
+        base: polygons
+        lighting: false
     heightglow:
         base: polygons
         lighting: vertex
         shaders:
             blocks:
-                color: "color.rgb += vec3(0.3 * position.z * exp2(16. - abs(u_tile_zoom)));"
+                color: "color.rgb += vec3(0.3 * position.z * exp2(16. - abs(u_tile_origin.z)));"
+    heightglowline:
+        base: lines
+        lighting: vertex
+        shaders:
+            blocks:
+                color: "color.rgb += vec3(0.3 * position.z * exp2(16. - abs(u_tile_origin.z)));"
 
     icons:
         base: points
@@ -123,7 +135,7 @@ layers:
                 - { $zoom: { min: 15 }, area: { min: 1000 } }
                 - { $zoom: { min: 18 } }
         draw:
-            polygons:
+            flatcolor:
                 order: 3
                 color: '#8db7d5'
 
@@ -293,6 +305,12 @@ layers:
             draw:
                 heightglow:
                     extrude: true
+            draw:
+                heightglowline:
+                    width: 1.0
+                    color: [.75, .75, .73]
+                    order: 52
+                    extrude: true
         high-line:
             filter: {roof_material: grass}
             draw:
@@ -326,7 +344,7 @@ layers:
                     style: normal
                     size: 1.em
                     fill: black
-
+                    stroke: { color: white, width: 2 }
         highway:
             filter: { kind: highway }
             draw:
@@ -393,7 +411,7 @@ layers:
             # this filter shows lower scaleranks at higher zooms, starting at z4
             #filter: function() { return (feature.scalerank * .75) <= ($zoom - 4); }
     landuse_labels:
-        data: { source: osm }
+        data: { source: osm, layer: [landuse_labels, pois] }
         filter:
             name: true
             kind: [park, forest, cemetery, graveyard]
@@ -419,6 +437,5 @@ layers:
         data: { source: osm }
         draw:
             sprites: {}
-
 
 


### PR DESCRIPTION
- fixes "shader compilation issue" and `validate_vertex_attribute_state: No vertex attrib is enabled in the draw!` log messages
        - seems to be caused by trying to use a uniform in the scene yaml, which was removed in the recent changes made
        to tangram