### PR TITLE
Adds multidex support library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,6 +92,7 @@ dependencies {
   compile 'com.splunk.mint:mint:4.2.1'
   compile 'com.squareup.okhttp:okhttp:2.4.0'
   compile 'com.mapzen.android:speakerbox:1.1.0'
+  compile 'com.android.support:multidex:1.0.1'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.9.5'

--- a/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
+++ b/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
@@ -7,13 +7,13 @@ import com.mapzen.erasermap.view.RouteModeView;
 import com.mapzen.erasermap.view.SearchResultsAdapter;
 import com.mapzen.erasermap.view.SettingsActivity;
 
-import android.app.Application;
+import android.support.multidex.MultiDexApplication;
 
 import javax.inject.Singleton;
 
 import dagger.Component;
 
-public class EraserMapApplication extends Application {
+public class EraserMapApplication extends MultiDexApplication {
     @Singleton
     @Component(modules = { AndroidModule.class, CommonModule.class })
     public interface ApplicationComponent {

--- a/app/src/test/java/com/mapzen/erasermap/PrivateMapsTestRunner.java
+++ b/app/src/test/java/com/mapzen/erasermap/PrivateMapsTestRunner.java
@@ -4,6 +4,7 @@ import com.mapzen.erasermap.shadows.ShadowGLSurfaceView;
 import com.mapzen.erasermap.shadows.ShadowMapController;
 import com.mapzen.erasermap.shadows.ShadowMapData;
 import com.mapzen.erasermap.shadows.ShadowMapView;
+import com.mapzen.erasermap.shadows.ShadowMultiDex;
 import com.mapzen.erasermap.shadows.ShadowPorterDuffColorFilter;
 
 import org.junit.runners.model.InitializationError;
@@ -26,6 +27,7 @@ public class PrivateMapsTestRunner extends RobolectricGradleTestRunner {
                 .addShadowClass(ShadowGLSurfaceView.class)
                 .addShadowClass(ShadowPorterDuffColorFilter.class)
                 .addShadowClass(ShadowMapData.class)
+                .addShadowClass(ShadowMultiDex.class)
                 .build();
     }
 

--- a/app/src/test/java/com/mapzen/erasermap/shadows/ShadowMultiDex.java
+++ b/app/src/test/java/com/mapzen/erasermap/shadows/ShadowMultiDex.java
@@ -1,0 +1,15 @@
+package com.mapzen.erasermap.shadows;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+import android.content.Context;
+import android.support.multidex.MultiDex;
+
+@Implements(MultiDex.class)
+public class ShadowMultiDex {
+    @Implementation
+    public static void install(Context context) {
+        // Do nothing.
+    }
+}


### PR DESCRIPTION
Fixes immediate crash at launch on pre-Lollipop devices. Dagger was unable to resolve generated classes built into additional dex files.