### PR TITLE
Init tile cache on KitKat and newer only!

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/model/TileHttpHandler.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/TileHttpHandler.kt
@@ -1,14 +1,21 @@
 package com.mapzen.erasermap.model
 
 import android.app.Application
+import android.os.Build
 import com.mapzen.tangram.HttpHandler
 import com.squareup.okhttp.Callback
 import java.io.File
 
 public class TileHttpHandler(application: Application) : HttpHandler() {
+    companion object {
+        @JvmStatic val KITKAT = 19
+    }
+
     init {
-        val httpCache = File(application.externalCacheDir.absolutePath + "/tile_cache")
-        setCache(httpCache, 30 * 1024 * 1024)
+        if (Build.VERSION.SDK_INT >= KITKAT) {
+            val httpCache = File(application.externalCacheDir.absolutePath + "/tile_cache")
+            setCache(httpCache, 30 * 1024 * 1024)
+        }
     }
 
     var apiKey: String? = null


### PR DESCRIPTION
Unfortunately because of how Kotlin handles Java static fields we are unable to use [`Build.VERSION_CODES.KITKAT`](https://developer.android.com/reference/android/os/Build.VERSION_CODES.html#KITKAT). Kotlin resolves this value at runtime instead of compile time which produces a [`NoSuchFieldError`](https://developer.android.com/reference/java/lang/NoSuchFieldError.html) and crashes the application when running on OS versions prior to KitKat.