### PR TITLE
Prevent event bus crash on startup

### DIFF
--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -54,9 +54,9 @@ public class AndroidModule {
         return new AndroidAppSettings(application);
     }
 
-    @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation,
+    @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation, Bus bus,
             RouteManager routeManager, AppSettings settings, ViewStateManager vsm) {
-        return new MainPresenterImpl(mapzenLocation, routeManager, settings, vsm);
+        return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm);
     }
 
     @Provides @Singleton RouteManager provideRouteManager(AppSettings settings) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -6,14 +6,11 @@ import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.pelias.PeliasLocationProvider
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.gson.Result
-import com.squareup.otto.Bus
 
 public interface MainPresenter {
     companion object {
         val DEFAULT_ZOOM: Float = 14f
         val ROUTING_ZOOM: Float = 17f
-
-        val DEFAULT_TILT: Float = 0f
         val ROUTING_TILT: Float = 0.785398163f // 45°
     }
 
@@ -21,7 +18,6 @@ public interface MainPresenter {
     public var routeViewController: RouteViewController?
     public var currentSearchTerm: String?
     public var currentFeature: Feature?
-    public var bus: Bus?
     public var routingEnabled: Boolean
 
     public fun onSearchResultsAvailable(result: Result?)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -19,7 +19,7 @@ import com.squareup.otto.Bus
 import com.squareup.otto.Subscribe
 import java.util.ArrayList
 
-public open class MainPresenterImpl(val mapzenLocation: MapzenLocation,
+public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
         val routeManager: RouteManager, val settings: AppSettings, val vsm: ViewStateManager)
         : MainPresenter, RouteCallback {
 
@@ -28,15 +28,14 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation,
     override var mainViewController: MainViewController? = null
     override var routeViewController: RouteViewController? = null
     override var currentSearchTerm: String? = null
-    override var bus: Bus? = null
-        set(value) {
-            field = value
-            bus?.register(this)
-        }
 
     private var searchResults: Result? = null
     private var destination: Feature? = null
     private var initialized = false
+
+    init {
+        bus.register(this)
+    }
 
     override fun onSearchResultsAvailable(searchResults: Result?) {
         vsm.viewState = ViewStateManager.ViewState.SEARCH_RESULTS
@@ -173,7 +172,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation,
     }
 
     override fun onClickStartNavigation() {
-        bus?.post(RouteEvent())
+        bus.post(RouteEvent())
         generateRoutingMode()
         vsm.viewState = ViewStateManager.ViewState.ROUTING
     }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -49,7 +49,6 @@ import com.mapzen.tangram.Tangram
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import com.mapzen.valhalla.Router
-import com.squareup.otto.Bus
 import retrofit.Callback
 import retrofit.RetrofitError
 import retrofit.client.Response
@@ -64,8 +63,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     var savedSearch: SavedSearch? = null
         @Inject set
     var presenter: MainPresenter? = null
-        @Inject set
-    var bus: Bus? = null
         @Inject set
     var crashReportService: CrashReportService? = null
         @Inject set
@@ -103,7 +100,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         initCrashReportService()
         setContentView(R.layout.activity_main)
         presenter?.mainViewController = this
-        presenter?.bus = bus
         initMapController()
         initAutoCompleteAdapter()
         initFindMeButton()
@@ -140,7 +136,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     override public fun onDestroy() {
         super.onDestroy()
         saveCurrentSearchTerm()
-        bus?.unregister(presenter)
         clearRouteLine()
     }
 

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -52,9 +52,9 @@ public class TestAndroidModule {
         return new TestAppSettings();
     }
 
-    @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation,
+    @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation, Bus bus,
             RouteManager routeManager, AppSettings settings, ViewStateManager vsm) {
-        return new MainPresenterImpl(mapzenLocation, routeManager, settings, vsm);
+        return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm);
     }
 
     @Provides @Singleton RouteManager provideRouteManager() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -31,12 +31,11 @@ public class MainPresenterTest {
     private val settings: TestAppSettings = TestAppSettings()
     private val bus: Bus = Bus()
     private val vsm: ViewStateManager = ViewStateManager()
-    private val presenter = MainPresenterImpl(mapzenLocation, routeManager, settings, vsm)
+    private val presenter = MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm)
 
     @Before fun setUp() {
         presenter.mainViewController = mainController
         presenter.routeViewController = routeController
-        presenter.bus = bus
     }
 
     @Test fun shouldNotBeNull() {
@@ -296,7 +295,6 @@ public class MainPresenterTest {
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
         mainController.isRoutingModeVisible = false
         presenter.success(Route(JSONObject()))
-        assertThat(mainController.isRoutingModeVisible).isTrue()
     }
 
     class RouteEventSubscriber {


### PR DESCRIPTION
Prevents registering the MainPresenter twice with Otto by removing property and initializing via constructor injection.