### PR TITLE
Adds auto-complete saved searches

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
@@ -34,12 +34,12 @@ public class ValhallaRouteManager(val settings: AppSettings) : RouteManager {
         val simpleFeature = SimpleFeature.fromFeature(destination)
         if (location is Location) {
             val start: DoubleArray = doubleArrayOf(location.latitude, location.longitude)
-            val dest: DoubleArray = doubleArrayOf(simpleFeature.lat, simpleFeature.lon)
+            val dest: DoubleArray = doubleArrayOf(simpleFeature.lat(), simpleFeature.lng())
             val units: Router.DistanceUnits = settings.distanceUnits
             val name = destination?.properties?.name
-            val street = simpleFeature.title
-            val city = simpleFeature.city
-            val state = simpleFeature.admin
+            val street = simpleFeature.name()
+            val city = simpleFeature.localAdmin()
+            val state = simpleFeature.region()
             val router = getInitializedRouter(type)
 
             if (location.hasBearing()) {
@@ -59,7 +59,7 @@ public class ValhallaRouteManager(val settings: AppSettings) : RouteManager {
         val location = origin
         val simpleFeature = SimpleFeature.fromFeature(destination)
         if (location is Location) {
-            val start: DoubleArray = doubleArrayOf(simpleFeature.lat, simpleFeature.lon)
+            val start: DoubleArray = doubleArrayOf(simpleFeature.lat(), simpleFeature.lng())
             val dest: DoubleArray = doubleArrayOf(location.latitude, location.longitude)
             val units: Router.DistanceUnits = settings.distanceUnits
             getInitializedRouter(type)

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -376,7 +376,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         searchResults?.clear()
         for (feature in features) {
             val simpleFeature = SimpleFeature.fromFeature(feature)
-            val lngLat = LngLat(simpleFeature.lon, simpleFeature.lat)
+            val lngLat = LngLat(simpleFeature.lng(), simpleFeature.lat())
             val properties = com.mapzen.tangram.Properties()
             properties.add("type", "point");
 
@@ -391,7 +391,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
                 val pager = findViewById(R.id.search_results) as SearchResultsView
                 val position = pager.getCurrentItem()
                 val feature = SimpleFeature.fromFeature(features[position])
-                mapController?.setMapPosition(feature.lon, feature.lat)
+                mapController?.setMapPosition(feature.lng(), feature.lat())
                 mapController?.mapZoom = MainPresenter.DEFAULT_ZOOM
             }
         }, 100)

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -409,7 +409,7 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
 
     private fun initDestination(destination: Feature) {
         val simpleFeature = SimpleFeature.fromFeature(destination)
-        (findViewById(R.id.destination_name) as TextView).text = simpleFeature.toString()
+        (findViewById(R.id.destination_name) as TextView).text = simpleFeature.label()
     }
 
     private fun initInstructionAdapter() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
@@ -24,12 +24,12 @@ public class RoutePreviewView : RelativeLayout {
         set (value) {
             field = value
             if (value) {
-                startView?.text = destination?.title
+                startView?.text = destination?.name()
                 destinationView?.setText(R.string.current_location)
                 startNavigationButton?.visibility = GONE
             } else {
                 startView?.setText(R.string.current_location)
-                destinationView?.text = destination?.title
+                destinationView?.text = destination?.name()
                 startNavigationButton?.visibility = VISIBLE
 
             }
@@ -39,7 +39,7 @@ public class RoutePreviewView : RelativeLayout {
         set (value) {
             field = value
             startView?.setText(R.string.current_location)
-            destinationView?.text = value?.title
+            destinationView?.text = value?.name()
         }
 
     public var route: Route? = null

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsAdapter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsAdapter.kt
@@ -21,7 +21,7 @@ public class SearchResultsAdapter(val context: Context, val features: List<Featu
         @Inject set
 
     init {
-        (context.getApplicationContext() as EraserMapApplication).component()
+        (context.applicationContext as EraserMapApplication).component()
                 .inject(this@SearchResultsAdapter)
     }
 
@@ -31,15 +31,15 @@ public class SearchResultsAdapter(val context: Context, val features: List<Featu
         val title = view.findViewById(R.id.title) as TextView
         val address = view.findViewById(R.id.address) as TextView
         val start = view.findViewById(R.id.preview) as ImageButton
-        title.setText(simpleFeature.getTitle())
-        address.setText(simpleFeature.getAddress())
+        title.text = simpleFeature.name()
+        address.text = simpleFeature.address()
         start.setOnClickListener { bus?.post(RoutePreviewEvent(features.get(position))) }
         container?.addView(view)
         return view
     }
 
     override fun getCount(): Int {
-        return features.size()
+        return features.size
     }
 
     override fun isViewFromObject(view: View?, `object`: Any?): Boolean {

--- a/app/src/test/java/com/mapzen/erasermap/dummy/TestHelper.java
+++ b/app/src/test/java/com/mapzen/erasermap/dummy/TestHelper.java
@@ -1,17 +1,18 @@
 package com.mapzen.erasermap.dummy;
 
-import android.location.Location;
-
-import com.google.common.io.Files;
 import com.mapzen.pelias.SimpleFeature;
 import com.mapzen.pelias.gson.Feature;
 import com.mapzen.pelias.gson.Geometry;
 import com.mapzen.pelias.gson.Properties;
 import com.mapzen.valhalla.Instruction;
 
+import com.google.common.io.Files;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.mockito.Mockito;
+
+import android.location.Location;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,10 +23,11 @@ import java.util.List;
 import static java.lang.System.getProperty;
 
 public class TestHelper {
-    public static final String TEST_TEXT = "Text";
+    public static final String TEST_NAME = "Name";
     public static final String TEST_LOCALITY = "Locality";
     public static final String TEST_LOCAL_ADMIN = "Local Admin";
     public static final String TEST_ADMIN1_ABBR = "Admin1 Abbr";
+    public static final String TEST_LABEL = "Name, Local Admin, Admin1 Abbr";
 
     public static Feature getTestFeature() {
         return getTestFeature(0.0, 0.0);
@@ -34,17 +36,18 @@ public class TestHelper {
     public static Feature getTestFeature(double lat, double lon) {
         Feature feature = new Feature();
         Properties properties = new Properties();
-        properties.setLabel(TEST_TEXT);
-        properties.setLocality(TEST_LOCALITY);
-        properties.setLocalAdmin(TEST_LOCAL_ADMIN);
-        properties.setRegion_a(TEST_ADMIN1_ABBR);
-        feature.setProperties(properties);
+        properties.name = TEST_NAME;
+        properties.locality = TEST_LOCALITY;
+        properties.localadmin = TEST_LOCAL_ADMIN;
+        properties.region_a = TEST_ADMIN1_ABBR;
+        properties.label = TEST_LABEL;
+        feature.properties = properties;
         Geometry geometry = new Geometry();
         List<Double> coordinates = new ArrayList<>();
         coordinates.add(lon);
         coordinates.add(lat);
-        geometry.setCoordinates(coordinates);
-        feature.setGeometry(geometry);
+        geometry.coordinates = coordinates;
+        feature.geometry = geometry;
         return feature;
     }
 

--- a/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
+++ b/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
@@ -15,7 +15,10 @@ import com.mapzen.android.lost.api.LocationServices
 import com.mapzen.erasermap.BuildConfig
 import com.mapzen.erasermap.PrivateMapsTestRunner
 import com.mapzen.erasermap.R
-import com.mapzen.erasermap.dummy.TestHelper.*
+import com.mapzen.erasermap.dummy.TestHelper
+import com.mapzen.erasermap.dummy.TestHelper.getFixture
+import com.mapzen.erasermap.dummy.TestHelper.getTestFeature
+import com.mapzen.erasermap.dummy.TestHelper.getTestLocation
 import com.mapzen.erasermap.presenter.MainPresenter
 import com.mapzen.erasermap.shadows.ShadowMapData
 import com.mapzen.pelias.SavedSearch
@@ -403,10 +406,9 @@ public class MainActivityTest {
         val features = ArrayList<Feature>()
         features.add(getTestFeature(30.0, 30.0))
         activity.showReverseGeocodeFeature(features)
-        assertThat(activity.findViewById(R.id.search_results).getVisibility()).isEqualTo(
-                View.VISIBLE)
+        assertThat(activity.findViewById(R.id.search_results).visibility).isEqualTo(View.VISIBLE)
         assertThat(((activity.findViewById(R.id.search_results).findViewById(R.id.title))
-                as TextView).getText()).isEqualTo("Text")
+                as TextView).text).isEqualTo(TestHelper.TEST_NAME)
     }
 
     @Test

--- a/app/src/test/java/com/mapzen/erasermap/view/RouteModeViewTest.java
+++ b/app/src/test/java/com/mapzen/erasermap/view/RouteModeViewTest.java
@@ -1,20 +1,9 @@
 package com.mapzen.erasermap.view;
 
-import android.annotation.TargetApi;
-import android.content.Context;
-import android.graphics.drawable.ColorDrawable;
-import android.location.Location;
-import android.os.Build;
-import android.support.v4.view.ViewPager;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ImageButton;
-import android.widget.ImageView;
-import android.widget.TextView;
-
 import com.mapzen.erasermap.BuildConfig;
 import com.mapzen.erasermap.PrivateMapsTestRunner;
 import com.mapzen.erasermap.R;
+import com.mapzen.erasermap.dummy.TestHelper;
 import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
 import com.mapzen.valhalla.Route;
@@ -26,6 +15,18 @@ import org.mockito.Mockito;
 import org.robolectric.Robolectric;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.graphics.drawable.ColorDrawable;
+import android.location.Location;
+import android.os.Build;
+import android.support.v4.view.ViewPager;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageButton;
+import android.widget.ImageView;
+import android.widget.TextView;
 
 import static com.mapzen.erasermap.dummy.TestHelper.getFixture;
 import static com.mapzen.erasermap.dummy.TestHelper.getTestFeature;
@@ -163,7 +164,7 @@ public class RouteModeViewTest {
         TextView distance = (TextView) startActivity.findViewById(R.id.destination_distance);
         TextView destinationText = (TextView) startActivity.findViewById(R.id.destination_name);
         assertThat(distance.getText().toString()).isEqualTo("1.2 mi");
-        assertThat(destinationText.getText()).isEqualTo("Text, Local Admin, Admin1 Abbr");
+        assertThat(destinationText.getText()).isEqualTo(TestHelper.TEST_LABEL);
     }
 
     @Test

--- a/app/src/test/java/com/mapzen/erasermap/view/RoutePreviewViewTest.java
+++ b/app/src/test/java/com/mapzen/erasermap/view/RoutePreviewViewTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
 
-import static com.mapzen.erasermap.dummy.TestHelper.TEST_TEXT;
+import static com.mapzen.erasermap.dummy.TestHelper.TEST_NAME;
 import static com.mapzen.erasermap.dummy.TestHelper.getTestSimpleFeature;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -38,7 +38,7 @@ public class RoutePreviewViewTest {
     @Test
     public void setDestination_shouldPopulateTextView() throws Exception {
         routePreview.setDestination(getTestSimpleFeature());
-        assertThat(routePreview.getDestinationView().getText()).isEqualTo(TEST_TEXT);
+        assertThat(routePreview.getDestinationView().getText()).isEqualTo(TEST_NAME);
     }
 
     @Test
@@ -64,7 +64,7 @@ public class RoutePreviewViewTest {
         routePreview.setDestination(getTestSimpleFeature());
         routePreview.setRoute(route);
         routePreview.setReverse(true);
-        assertThat(routePreview.getStartView().getText().toString()).isEqualTo(TEST_TEXT);
+        assertThat(routePreview.getStartView().getText().toString()).isEqualTo(TEST_NAME);
         assertThat(routePreview.getDestinationView().getText()).isEqualTo("Current Location");
     }
 }

--- a/app/src/test/java/com/mapzen/erasermap/view/SearchResultsAdapterTest.java
+++ b/app/src/test/java/com/mapzen/erasermap/view/SearchResultsAdapterTest.java
@@ -45,7 +45,7 @@ public class SearchResultsAdapterTest {
         ViewGroup container = new FrameLayout(application);
         View view = (View) adapter.instantiateItem(container, 0);
         TextView text = (TextView) view.findViewById(R.id.title);
-        assertThat(text.getText()).isEqualTo(SimpleFeature.fromFeature(feature).getTitle());
+        assertThat(text.getText()).isEqualTo(SimpleFeature.fromFeature(feature).name());
     }
 
     @Test
@@ -53,7 +53,7 @@ public class SearchResultsAdapterTest {
         ViewGroup container = new FrameLayout(application);
         View view = (View) adapter.instantiateItem(container, 0);
         TextView text = (TextView) view.findViewById(R.id.address);
-        assertThat(text.getText()).isEqualTo(SimpleFeature.fromFeature(feature).getAddress());
+        assertThat(text.getText()).isEqualTo(SimpleFeature.fromFeature(feature).address());
     }
 
     @Test
@@ -89,8 +89,8 @@ public class SearchResultsAdapterTest {
         RoutePreviewSubscriber subscriber = new RoutePreviewSubscriber();
         adapter.getBus().register(subscriber);
         start.performClick();
-        assertThat(subscriber.event.getDestination().getProperties().getLabel())
-                .isEqualTo(getTestFeature().getProperties().getLabel());
+        assertThat(subscriber.event.getDestination().properties.label)
+                .isEqualTo(getTestFeature().properties.label);
     }
 
     public static class RoutePreviewSubscriber {


### PR DESCRIPTION
Tapping on an autocomplete item in recent searches takes user directly to to the same result. Denotes saved auto-complete items with a pin rather than timer icon.

* Persist payload for auto-complete items
* Reconstruct features for saved items in recent list
* Feature and SimpleFeature API updates

Closes #87 

![image](https://cloud.githubusercontent.com/assets/464123/11415506/eaeab00a-93d1-11e5-8373-a4c269b9cc35.png)
