### PR TITLE
Fix display text when viewing all search result

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsListActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsListActivity.kt
@@ -1,9 +1,9 @@
 package com.mapzen.erasermap.view
 
+import android.content.Context
 import android.os.Bundle
-import android.support.v7.app.AppCompatActivity
-import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.ListView
 import android.widget.TextView
@@ -19,22 +19,35 @@ public class SearchResultsListActivity : HomeAsUpActivity() {
         val listView = findViewById(R.id.search_results_list_view) as ListView
         val headerView = View.inflate(this, R.layout.list_header_search_results, null)
         val title = headerView.findViewById(R.id.title) as TextView
-        val bundle = getIntent()?.getExtras()
+        val bundle = intent?.extras
         val query = bundle?.getString("query")
         val simpleFeatures: ArrayList<SimpleFeature>? = bundle?.getParcelableArrayList("features")
 
         if (query != null) {
-            title.setText("\"" + query + "\"")
+            title.text = "\"" + query + "\""
             listView.addHeaderView(headerView, null, false)
             listView.setHeaderDividersEnabled(false)
         }
 
         if (simpleFeatures != null) {
-            listView.setAdapter(ArrayAdapter(this, R.layout.list_item_search_results, simpleFeatures))
+            listView.adapter = SearchListAdapter(this, R.layout.list_item_search_results, simpleFeatures)
             listView.setOnItemClickListener { parent, view, position, id ->
                 setResult(position)
                 finish()
             }
+        }
+    }
+
+    /**
+     * Adapter for SimpleFeatures that uses label() rather than toString() for display text.
+     */
+    class SearchListAdapter(context: Context, resource: Int, val objects: List<SimpleFeature>) :
+            ArrayAdapter<SimpleFeature>(context, resource, objects) {
+
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View? {
+            val view = super.getView(position, convertView, parent) as TextView
+            view.text = objects[position].label()
+            return view
         }
     }
 }

--- a/app/src/test/java/com/mapzen/erasermap/view/SearchResultsListActivityTest.java
+++ b/app/src/test/java/com/mapzen/erasermap/view/SearchResultsListActivityTest.java
@@ -2,6 +2,9 @@ package com.mapzen.erasermap.view;
 
 import com.mapzen.erasermap.BuildConfig;
 import com.mapzen.erasermap.PrivateMapsTestRunner;
+import com.mapzen.erasermap.R;
+import com.mapzen.erasermap.dummy.TestHelper;
+import com.mapzen.pelias.SimpleFeature;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -9,8 +12,14 @@ import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
 import org.robolectric.fakes.RoboMenuItem;
+import org.robolectric.util.ActivityController;
 
+import android.content.Intent;
 import android.view.MenuItem;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,5 +43,22 @@ public class SearchResultsListActivityTest {
         MenuItem menuItem = new RoboMenuItem(android.R.id.home);
         activity.onOptionsItemSelected(menuItem);
         assertThat(activity.isFinishing()).isTrue();
+    }
+
+    @Test
+    public void shouldPopulateListViewWithLabel() throws Exception {
+        ActivityController<SearchResultsListActivity> controller =
+                Robolectric.buildActivity(SearchResultsListActivity.class);
+
+        ArrayList<SimpleFeature> simpleFeatures = new ArrayList<>();
+        SimpleFeature simpleFeature = TestHelper.getTestSimpleFeature();
+        simpleFeatures.add(simpleFeature);
+        Intent intent = new Intent();
+        intent.putExtra("features", simpleFeatures);
+        activity = controller.withIntent(intent).create().get();
+
+        ListView listView = (ListView) activity.findViewById(R.id.search_results_list_view);
+        TextView textView = (TextView) listView.getAdapter().getView(0, null, null);
+        assertThat(textView.getText()).isEqualTo(simpleFeature.label());
     }
 }


### PR DESCRIPTION
Implements custom `ArrayAdapter` that uses `SimpleFeature.label()` method for display text.

Closes #145 

![image](https://cloud.githubusercontent.com/assets/464123/11484497/435c7356-977c-11e5-92f0-ec86604768d4.png)
