### PR TITLE
Improve search UI back stack management

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -42,18 +42,20 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
         this.searchResults = searchResults
         mainViewController?.showSearchResults(searchResults?.getFeatures())
         mainViewController?.hideProgress()
-        val featureCount = searchResults?.getFeatures()?.size()
+        val featureCount = searchResults?.features?.size
         if (featureCount != null && featureCount > 1) {
             mainViewController?.showActionViewAll()
+            mainViewController?.hideOverflowMenu()
         } else {
             mainViewController?.hideActionViewAll()
+            mainViewController?.showOverflowMenu()
         }
     }
 
     override fun onReverseGeocodeResultsAvailable(searchResults: Result?) {
         var features = ArrayList<Feature>()
         this.searchResults = searchResults
-        if(searchResults?.getFeatures()?.isEmpty() as Boolean) {
+        if(searchResults?.features?.isEmpty() as Boolean) {
             val current = currentFeature
             if (current is Feature) {
                 features.add(current)
@@ -61,11 +63,11 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
             mainViewController?.showReverseGeocodeFeature(features)
             searchResults?.setFeatures(features)
         } else {
-            val current = searchResults?.getFeatures()?.get(0)
+            val current = searchResults?.features?.get(0)
             if (current is Feature) {
                 features.add(current)
             }
-            searchResults?.setFeatures(features)
+            searchResults?.features = features
             mainViewController?.showReverseGeocodeFeature(features)
         }
     }
@@ -90,7 +92,6 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
     override fun onExpandSearchView() {
         vsm.viewState = ViewStateManager.ViewState.SEARCH
-        mainViewController?.hideOverflowMenu()
     }
 
     override fun onCollapseSearchView() {
@@ -102,6 +103,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
         mainViewController?.hideSearchResults()
         mainViewController?.showOverflowMenu()
         mainViewController?.hideActionViewAll()
+        mainViewController?.clearQuery()
     }
 
     override fun onQuerySubmit() {
@@ -110,12 +112,12 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
     override fun onSearchResultSelected(position: Int) {
         if (searchResults != null) {
-            mainViewController?.centerOnCurrentFeature(searchResults?.getFeatures())
+            mainViewController?.centerOnCurrentFeature(searchResults?.features)
         }
     }
 
     override fun onViewAllSearchResults() {
-        mainViewController?.showAllSearchResults(searchResults?.getFeatures())
+        mainViewController?.showAllSearchResults(searchResults?.features)
     }
 
     @Subscribe public fun onRoutePreviewEvent(event: RoutePreviewEvent) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
@@ -17,6 +17,7 @@ public interface MainViewController {
     public fun showActionViewAll()
     public fun hideActionViewAll()
     public fun collapseSearchView()
+    public fun clearQuery()
     public fun showRoutePreview(location: Location, feature: Feature)
     public fun hideRoutePreview()
     public fun hideRoutingMode()

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -112,12 +112,6 @@ public class MainPresenterTest {
         assertThat(mainController.isProgressVisible).isFalse()
     }
 
-    @Test fun onExpandSearchView_shouldHideOverflowMenu() {
-        mainController.isOverflowVisible = true
-        presenter.onExpandSearchView()
-        assertThat(mainController.isOverflowVisible).isFalse()
-    }
-
     @Test fun onCollapseSearchView_shouldShowOverflowMenu() {
         mainController.isOverflowVisible = false
         presenter.onCollapseSearchView()
@@ -140,6 +134,12 @@ public class MainPresenterTest {
         mainController.isViewAllVisible = true
         presenter.onCollapseSearchView()
         assertThat(mainController.isViewAllVisible).isFalse()
+    }
+
+    @Test fun onCollapseSearchView_shouldClearQueryText() {
+        mainController.queryText = "query"
+        presenter.onCollapseSearchView()
+        assertThat(mainController.queryText).isEmpty()
     }
 
     @Test fun onRoutePreviewEvent_shouldCollapseSearchView() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
@@ -11,6 +11,7 @@ public class TestMainController : MainViewController {
     public var tilt: Float = 0f
     public var rotation: Float = 0f
     public var routeLine: List<LngLat>? = null
+    public var queryText: String = ""
 
     public var isProgressVisible: Boolean = false
     public var isOverflowVisible: Boolean = false
@@ -63,6 +64,10 @@ public class TestMainController : MainViewController {
 
     override fun collapseSearchView() {
         isSearchVisible = false
+    }
+
+    override fun clearQuery() {
+        queryText = ""
     }
 
     override fun showRoutePreview(location: Location, feature: Feature) {


### PR DESCRIPTION
Prevents situation where you would be unable to clear search results and back button instead would exit the application.

* Remove action view expand listener since search is now always expanded
* Trigger "expand" when search view gains focus and "collapse" on back pressed
* Remove hacky search view width calculations
* Always show overflow or view all action to preserve correct spacing
* Clear query text on exit search

Closes #132