### PR TITLE
Center location maker in bottom half of screen in routing mode

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.view
 
 import android.content.Context
+import android.graphics.Point
 import android.location.Location
 import android.support.v4.view.PagerAdapter
 import android.support.v4.view.ViewPager
@@ -8,6 +9,7 @@ import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
+import android.view.WindowManager
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -335,6 +337,19 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
         mapController?.setMapRotation(getBearingInRadians(location), 1f, MapController.EaseType.LINEAR)
         mapController?.mapZoom = MainPresenter.ROUTING_ZOOM
         mapController?.mapTilt = MainPresenter.ROUTING_TILT
+        adjustMapPosition()
+    }
+
+    private fun adjustMapPosition() {
+        val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        val display = windowManager.defaultDisplay
+        val point = Point()
+        display.getSize(point)
+
+        val screenWidth = point.x.toDouble()
+        val screenHeight = point.y.toDouble()
+        val position = mapController?.coordinatesAtScreenPosition(screenWidth/2, screenHeight/4)
+        mapController?.mapPosition = position
     }
 
     override fun updateSnapLocation(location: Location) {


### PR DESCRIPTION
1. First the map position is set based on the device current location.
2. Second screen width and height for the device are queried using the `WindowManager`.
3. Once the map is centered on the current location then new `LngLat` coordinates are calculated for the adjusted position using `MapController.coordinatesAtScreenPosition(screenWidth/2, screenHeight/4)`.
4. Finally, the map position is set again using the new adjusted coordinates.

While successfully centering the route location marker in the bottom half of the screen this solution has the side effect of causing the map to flicker due to setting the map position twice in rapid succession.

@blair1618 @tallytalwar @karimnaaji is there a way to delay rendering until the final coordinates are calculated? Or is there a better approach we can use to implement this feature?

Closes #105

![image](https://cloud.githubusercontent.com/assets/464123/11646906/5f8b015a-9d30-11e5-9041-8cc595080948.png)
