### PR TITLE
Clear location markers on rotation

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -157,7 +157,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     private fun onBackPressedStateRoutePreview() {
         vsm.viewState = ViewStateManager.ViewState.SEARCH_RESULTS
         mainViewController?.hideRoutePreview()
-        mainViewController?.clearRouteLine()
+        mainViewController?.clearRoute()
     }
 
     private fun onBackPressedStateRouting() {
@@ -269,7 +269,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
         mainViewController?.hideProgress()
         routeManager.route = route
         generateRoutingMode()
-        mainViewController?.drawRouteLine(route)
+        mainViewController?.drawRoute(route)
     }
 
     private fun generateRoutePreview() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -197,12 +197,16 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     }
 
     override fun onCreate() {
-        if (!initialized) {
-            val currentLocation = mapzenLocation.getLastLocation()
-            if (currentLocation is Location) {
+        val currentLocation = mapzenLocation.getLastLocation()
+        if (currentLocation is Location) {
+            if (!initialized) {
+                // Show location puck and center map
                 mainViewController?.centerMapOnLocation(currentLocation, MainPresenter.DEFAULT_ZOOM)
+                initialized = true
+            } else {
+                // Just show location puck. Do not recenter map.
+                mainViewController?.showCurrentLocation(currentLocation)
             }
-            initialized = true
         }
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
@@ -17,4 +17,5 @@ public interface RoutePresenter {
     public fun onInstructionPagerTouch()
     public fun onInstructionSelected(instruction: Instruction)
     public fun onUpdateSnapLocation(location: Location)
+    public fun onRouteClear()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -64,4 +64,9 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
             routeController?.centerMapOnLocation(location)
         }
     }
+
+    override fun onRouteClear() {
+        routeController?.hideRouteIcon()
+        routeController?.hideRouteLine()
+    }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -149,6 +149,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         super.onDestroy()
         saveCurrentSearchTerm()
         routeModeView.clearRoute()
+        findMe?.clear()
     }
 
     private fun initMapController() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -73,7 +73,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     var mapController : MapController? = null
     var autoCompleteAdapter: AutoCompleteAdapter? = null
     var optionsMenu: Menu? = null
-    var routeLine: MapData? = null
     var findMe: MapData? = null
     var searchResults: MapData? = null
 
@@ -149,7 +148,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     override public fun onDestroy() {
         super.onDestroy()
         saveCurrentSearchTerm()
-        clearRouteLine()
+        routeModeView.clearRoute()
     }
 
     private fun initMapController() {
@@ -470,8 +469,12 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         route()
     }
 
-    override fun clearRouteLine() {
-        routeLine?.clear()
+    override fun drawRoute(route: Route) {
+        routeModeView.drawRoute(route)
+    }
+
+    override fun clearRoute() {
+        routeModeView.clearRoute()
     }
 
     override fun success(route: Route) {
@@ -484,29 +487,8 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
             }
         })
         updateRoutePreview()
-        drawRouteLine(route)
+        routeModeView.drawRoute(route)
         hideProgress()
-    }
-
-    override fun drawRouteLine(route: Route) {
-        val properties = com.mapzen.tangram.Properties()
-        properties.add("type", "line");
-        val geometry: ArrayList<Location>? = route.getGeometry()
-        val mapGeometry: ArrayList<LngLat> = ArrayList()
-        if (geometry is ArrayList<Location>) {
-            for (location in geometry) {
-                mapGeometry.add(LngLat(location.longitude, location.latitude))
-            }
-        }
-
-        if (routeLine == null) {
-            routeLine = MapData("route")
-            Tangram.addDataSource(routeLine);
-        }
-
-        routeLine?.clear()
-        routeLine?.addLine(properties, mapGeometry)
-        routeLine?.update();
     }
 
     override fun failure(statusCode: Int) {
@@ -605,7 +587,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         showRoutingMode(feature)
         val route = routeManager?.route
         if (route is Route) {
-            drawRouteLine(route)
+            drawRoute(route)
         }
         routeModeView.resumeRoute(feature, routeManager?.route)
     }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
@@ -29,7 +29,7 @@ public interface MainViewController {
     public fun showCurrentLocation(location: Location)
     public fun setMapTilt(radians: Float)
     public fun setMapRotation(radians: Float)
-    public fun drawRouteLine(route: Route)
-    public fun clearRouteLine()
+    public fun drawRoute(route: Route)
+    public fun clearRoute()
     public fun rotateCompass()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -63,6 +63,8 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
 
     private var currentSnapLocation: Location? = null
     private var routeIcon: MapData? = null
+    private var routeLine: MapData? = null
+
 
     public constructor(context: Context) : super(context) {
         init(context)
@@ -380,7 +382,7 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
         return Math.toRadians(360 - location.bearing.toDouble()).toFloat()
     }
 
-    fun hideRouteIcon() {
+    override fun hideRouteIcon() {
         routeIcon?.clear()
     }
 
@@ -419,5 +421,34 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
             val adapter = InstructionAdapter(context, instructions, this)
             setAdapter(adapter)
         }
+    }
+
+    public fun drawRoute(route: Route) {
+        val properties = com.mapzen.tangram.Properties()
+        properties.add("type", "line");
+        val geometry: ArrayList<Location>? = route.getGeometry()
+        val mapGeometry: ArrayList<LngLat> = ArrayList()
+        if (geometry is ArrayList<Location>) {
+            for (location in geometry) {
+                mapGeometry.add(LngLat(location.longitude, location.latitude))
+            }
+        }
+
+        if (routeLine == null) {
+            routeLine = MapData("route")
+            Tangram.addDataSource(routeLine);
+        }
+
+        routeLine?.clear()
+        routeLine?.addLine(properties, mapGeometry)
+        routeLine?.update();
+    }
+
+    override fun hideRouteLine() {
+        routeLine?.clear()
+    }
+
+    public fun clearRoute() {
+        routePresenter?.onRouteClear()
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteViewController.kt
@@ -22,4 +22,6 @@ public interface RouteViewController {
     public fun updateDistanceToDestination(meters: Int)
     public fun showRouteComplete()
     public fun showReroute(location: Location)
+    public fun hideRouteIcon()
+    public fun hideRouteLine()
 }

--- a/app/src/test/java/com/mapzen/erasermap/PrivateMapsTestRunner.java
+++ b/app/src/test/java/com/mapzen/erasermap/PrivateMapsTestRunner.java
@@ -5,6 +5,7 @@ import com.mapzen.erasermap.shadows.ShadowMapController;
 import com.mapzen.erasermap.shadows.ShadowMapData;
 import com.mapzen.erasermap.shadows.ShadowMapView;
 import com.mapzen.erasermap.shadows.ShadowPorterDuffColorFilter;
+import com.mapzen.erasermap.shadows.ShadowTangram;
 
 import org.junit.runners.model.InitializationError;
 import org.robolectric.RobolectricGradleTestRunner;
@@ -26,6 +27,7 @@ public class PrivateMapsTestRunner extends RobolectricGradleTestRunner {
                 .addShadowClass(ShadowGLSurfaceView.class)
                 .addShadowClass(ShadowPorterDuffColorFilter.class)
                 .addShadowClass(ShadowMapData.class)
+                .addShadowClass(ShadowTangram.class)
                 .build();
     }
 

--- a/app/src/test/java/com/mapzen/erasermap/shadows/ShadowTangram.java
+++ b/app/src/test/java/com/mapzen/erasermap/shadows/ShadowTangram.java
@@ -1,0 +1,25 @@
+package com.mapzen.erasermap.shadows;
+
+import com.mapzen.tangram.DataSource;
+import com.mapzen.tangram.Tangram;
+
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+import org.robolectric.shadows.ShadowSurfaceView;
+
+import java.util.ArrayList;
+
+@Implements(Tangram.class)
+public class ShadowTangram extends ShadowSurfaceView {
+    public static ArrayList<DataSource> dataSources = new ArrayList<>();
+
+    @Implementation
+    public static void addDataSource(DataSource source) {
+        dataSources.add(source);
+    }
+
+    @Implementation
+    public static void clearDataSource(DataSource source, boolean data, boolean tiles) {
+        dataSources.remove(source);
+    }
+}

--- a/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
+++ b/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
@@ -436,6 +436,14 @@ public class MainActivityTest {
     }
 
     @Test
+    public fun onDestroy_shouldClearFindMeIcon() {
+        activity.showCurrentLocation(getTestLocation())
+        val shadowMapData = ShadowExtractor.extract(activity.findMe) as ShadowMapData
+        activity.onDestroy()
+        assertThat(shadowMapData.points).isNullOrEmpty()
+    }
+
+    @Test
     public fun resumeRoutingMode_shouldDrawRouteLine() {
         activity.routeManager?.route = TestRoute()
         activity.resumeRoutingMode(getTestFeature())

--- a/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
+++ b/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
@@ -21,11 +21,11 @@ import com.mapzen.erasermap.dummy.TestHelper.getTestFeature
 import com.mapzen.erasermap.dummy.TestHelper.getTestLocation
 import com.mapzen.erasermap.presenter.MainPresenter
 import com.mapzen.erasermap.shadows.ShadowMapData
+import com.mapzen.erasermap.shadows.ShadowTangram
 import com.mapzen.pelias.SavedSearch
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.widget.PeliasSearchView
 import com.mapzen.tangram.LngLat
-import com.mapzen.tangram.MapData
 import com.mapzen.tangram.MapView
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.Router
@@ -231,22 +231,22 @@ public class MainActivityTest {
         activity.showRoutePreview(getTestLocation(), getTestFeature())
         activity.success(TestRoute())
         Robolectric.flushForegroundThreadScheduler()
-        assertThat((ShadowExtractor.extract(activity.routeLine) as ShadowMapData).line).isNotNull()
+        val routeLine = ShadowTangram.dataSources[0]
+        assertThat((ShadowExtractor.extract(routeLine) as ShadowMapData).line).isNotNull()
     }
 
     @Test
     public fun showRoutePreview_shouldClearPreviousRouteLine() {
         val properties = com.mapzen.tangram.Properties()
         properties.add("type", "line");
-        val routeLine = ArrayList<LngLat>()
-        routeLine.add(LngLat())
-        activity.routeLine = MapData("route")
-        activity.routeLine?.addLine(properties, routeLine)
+        val old = ArrayList<LngLat>()
+        old.add(LngLat())
+        activity.routeModeView.drawRoute(TestRoute())
         activity.showRoutePreview(getTestLocation(), getTestFeature())
         activity.success(TestRoute())
         Robolectric.flushForegroundThreadScheduler()
-        assertThat((ShadowExtractor.extract(activity.routeLine) as ShadowMapData).line)
-                .isNotSameAs(routeLine)
+        val new = ShadowTangram.dataSources[0]
+        assertThat(old).isNotSameAs(new)
     }
 
     @Test
@@ -439,7 +439,8 @@ public class MainActivityTest {
     public fun resumeRoutingMode_shouldDrawRouteLine() {
         activity.routeManager?.route = TestRoute()
         activity.resumeRoutingMode(getTestFeature())
-        val shadowMapData = ShadowExtractor.extract(activity.routeLine) as ShadowMapData
+        val routeLine = ShadowTangram.dataSources[0]
+        val shadowMapData = ShadowExtractor.extract(routeLine) as ShadowMapData
         assertThat(shadowMapData.line).isNotNull()
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -273,6 +273,13 @@ public class MainPresenterTest {
         assertThat(mainController.location).isNull()
     }
 
+    @Test fun onCreate_shouldShowCurrentLocationSecondTimeInvoked() {
+        presenter.onCreate()
+        mainController.puckPosition = null
+        presenter.onCreate()
+        assertThat(mainController.puckPosition).isNotNull()
+    }
+
     @Test fun onReroute_shouldShowProgress() {
         routeManager.reset()
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -87,4 +87,16 @@ public class RoutePresenterTest {
         routePresenter.onInstructionSelected(instruction)
         assertThat(routeController.mapLocation).isEqualTo(location)
     }
+
+    @Test fun onClearRoute_shouldHideRouteIcon() {
+        routeController.isRouteIconVisible = true
+        routePresenter.onRouteClear()
+        assertThat(routeController.isRouteIconVisible).isFalse()
+    }
+
+    @Test fun onClearRoute_shouldHideRouteLine() {
+        routeController.isRouteLineVisible = true
+        routePresenter.onRouteClear()
+        assertThat(routeController.isRouteLineVisible).isFalse()
+    }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
@@ -117,11 +117,11 @@ public class TestMainController : MainViewController {
         isReverseGeocodeVisible = true
     }
 
-    override fun drawRouteLine(route: Route) {
+    override fun drawRoute(route: Route) {
         routeLine = route
     }
 
-    override fun clearRouteLine() {
+    override fun clearRoute() {
         routeLine = null
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
@@ -12,6 +12,7 @@ public class TestMainController : MainViewController {
     public var rotation: Float = 0f
     public var routeLine: Route? = null
     public var queryText: String = ""
+    public var puckPosition: Location? = null
 
     public var isProgressVisible: Boolean = false
     public var isOverflowVisible: Boolean = false
@@ -103,6 +104,7 @@ public class TestMainController : MainViewController {
     }
 
     override fun showCurrentLocation(location: Location) {
+        puckPosition = location
     }
 
     override fun setMapTilt(radians: Float) {

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
@@ -8,6 +8,8 @@ public class TestRouteController : RouteViewController {
     public var mapLocation: Location? = null
     public var isDirectionListVisible: Boolean = false
     public var isResumeButtonVisible: Boolean = false
+    public var isRouteIconVisible: Boolean = false
+    public var isRouteLineVisible: Boolean = false
 
     override fun onLocationChanged(location: Location) {
         this.location = location
@@ -67,5 +69,13 @@ public class TestRouteController : RouteViewController {
     }
 
     override fun updateSnapLocation(location: Location) {
+    }
+
+    override fun hideRouteIcon() {
+        isRouteIconVisible = false
+    }
+
+    override fun hideRouteLine() {
+        isRouteLineVisible = false
     }
 }

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -8,4 +8,5 @@
     <suppress checks="MemberName" files=".*src/test/java/*" />
     <suppress checks="MagicNumberCheck" files=".*src/test/java/*" />
     <suppress checks="[a-zA-Z0-9]*" files="MapzenAndroidManifest\.java" />
+    <suppress checks="VisibilityModifier" files="ShadowTangram\.java" />
 </suppressions>


### PR DESCRIPTION
Clears both route navigation and find me location markers on device rotation. Replaces markers when map is re-created. Adds `ShadowTangram` class to enable testing.

Closes #108 