### PR TITLE
Prevent long press to reverse geolocate in routing mode

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.presenter
 
 import android.location.Location
+import android.view.MotionEvent
 import com.mapzen.erasermap.view.MainViewController
 import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.pelias.PeliasLocationProvider
@@ -41,4 +42,5 @@ public interface MainPresenter {
     public fun getPeliasLocationProvider(): PeliasLocationProvider
     public fun onReroute(location: Location)
     public fun onMapMotionEvent(): Boolean
+    public fun onLongPressMap(event: MotionEvent): Boolean
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -2,6 +2,7 @@ package com.mapzen.erasermap.presenter
 
 import android.location.Location
 import android.util.Log
+import android.view.MotionEvent
 import com.mapzen.erasermap.model.AppSettings
 import com.mapzen.erasermap.model.LocationChangeEvent
 import com.mapzen.erasermap.model.MapzenLocation
@@ -302,6 +303,17 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
     override fun onMapMotionEvent(): Boolean {
         mainViewController?.rotateCompass()
+        return true
+    }
+
+    override fun onLongPressMap(event: MotionEvent): Boolean {
+        if (vsm.viewState == ViewStateManager.ViewState.ROUTE_PREVIEW
+                || vsm.viewState == ViewStateManager.ViewState.ROUTING
+                || vsm.viewState == ViewStateManager.ViewState.ROUTE_DIRECTION_LIST) {
+            return false
+        }
+
+        mainViewController?.reverseGeolocate(event)
         return true
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -155,8 +155,9 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     private fun initMapController() {
         val mapView = findViewById(R.id.map) as MapView
         mapController = MapController(this, mapView, "style/eraser-map.yaml")
-        mapController?.setLongPressListener(View.OnGenericMotionListener {
-            view, motionEvent -> reverseGeolocate(motionEvent) })
+        mapController?.setLongPressListener({
+            view, motionEvent -> presenter?.onLongPressMap(motionEvent) ?: false
+        })
         mapController?.setHttpHandler(tileHttpHandler)
         mapzenLocation?.mapController = mapController
     }
@@ -396,7 +397,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         }, 100)
     }
 
-    public fun reverseGeolocate(event: MotionEvent) : Boolean {
+    override fun reverseGeolocate(event: MotionEvent) {
         val pelias = Pelias.getPelias()
         pelias.setLocationProvider(presenter?.getPeliasLocationProvider())
         var coords  = mapController?.coordinatesAtScreenPosition(
@@ -405,7 +406,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
                 coords?.longitude as Double)
         pelias.reverse(coords?.latitude as Double, coords?.longitude as Double,
                 ReversePeliasCallback())
-        return true
     }
 
     override fun hideSearchResults() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.view
 
 import android.location.Location
+import android.view.MotionEvent
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.valhalla.Route
 
@@ -32,4 +33,5 @@ public interface MainViewController {
     public fun drawRoute(route: Route)
     public fun clearRoute()
     public fun rotateCompass()
+    public fun reverseGeolocate(event: MotionEvent)
 }

--- a/app/src/test/java/com/mapzen/erasermap/dummy/TestHelper.java
+++ b/app/src/test/java/com/mapzen/erasermap/dummy/TestHelper.java
@@ -13,6 +13,7 @@ import org.json.JSONObject;
 import org.mockito.Mockito;
 
 import android.location.Location;
+import android.view.MotionEvent;
 
 import java.io.File;
 import java.io.IOException;
@@ -94,5 +95,9 @@ public class TestHelper {
         Mockito.when(location.getBearing()).thenReturn(bearing);
         Mockito.when(location.hasBearing()).thenReturn(hasBearing);
         return location;
+    }
+
+    public static MotionEvent getLongPressMotionEvent() {
+        return Mockito.mock(MotionEvent.class);
     }
 }

--- a/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
+++ b/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
@@ -3,10 +3,8 @@ package com.mapzen.erasermap.view
 import android.content.ComponentName
 import android.content.Context.LOCATION_SERVICE
 import android.location.LocationManager
-import android.os.SystemClock
 import android.preference.PreferenceManager
 import android.support.v7.widget.SearchView
-import android.view.MotionEvent
 import android.view.View
 import android.view.View.GONE
 import android.view.View.VISIBLE
@@ -414,7 +412,7 @@ public class MainActivityTest {
     @Test
     public fun onLongClick_shouldSetPresenterFeature() {
         assertThat(activity.presenter!!.currentFeature).isNull()
-        activity.reverseGeolocate(getLongPressMotionEvent())
+        activity.reverseGeolocate(TestHelper.getLongPressMotionEvent())
         assertThat(activity.presenter!!.currentFeature).isNotNull()
     }
 
@@ -459,11 +457,6 @@ public class MainActivityTest {
             this.group = group
             this.visible = visible
         }
-    }
-
-    private fun getLongPressMotionEvent(): MotionEvent {
-        return MotionEvent.obtain(SystemClock.uptimeMillis(), SystemClock.uptimeMillis() + 501,
-                MotionEvent.ACTION_DOWN, 30.0f, 30.0f, 1.0f, 1.0f, 1, 1.0f, 1.0f, 0, 0)
     }
 
     private class TestRoute : Route(JSONObject()) {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -344,6 +344,25 @@ public class MainPresenterTest {
         assertThat(mainController.rotation).isEqualTo(0f)
     }
 
+    @Test fun onLongPressMap_shouldReverseGeolocate() {
+        presenter.onLongPressMap(TestHelper.getLongPressMotionEvent())
+        assertThat(mainController.reverseGeolocateEvent).isNotNull()
+    }
+
+    @Test fun onLongPressMap_shouldNotReverseGeolocateWhileRouting() {
+        presenter.vsm.viewState = ROUTE_PREVIEW
+        presenter.onLongPressMap(TestHelper.getLongPressMotionEvent())
+        assertThat(mainController.reverseGeolocateEvent).isNull()
+
+        presenter.vsm.viewState = ROUTING
+        presenter.onLongPressMap(TestHelper.getLongPressMotionEvent())
+        assertThat(mainController.reverseGeolocateEvent).isNull()
+
+        presenter.vsm.viewState = ROUTE_DIRECTION_LIST
+        presenter.onLongPressMap(TestHelper.getLongPressMotionEvent())
+        assertThat(mainController.reverseGeolocateEvent).isNull()
+    }
+
     class RouteEventSubscriber {
         public var event: RouteEvent? = null
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.view
 
 import android.location.Location
+import android.view.MotionEvent
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.valhalla.Route
 
@@ -13,6 +14,7 @@ public class TestMainController : MainViewController {
     public var routeLine: Route? = null
     public var queryText: String = ""
     public var puckPosition: Location? = null
+    public var reverseGeolocateEvent: MotionEvent? = null
 
     public var isProgressVisible: Boolean = false
     public var isOverflowVisible: Boolean = false
@@ -128,5 +130,9 @@ public class TestMainController : MainViewController {
     }
 
     override fun rotateCompass() {
+    }
+
+    override fun reverseGeolocate(event: MotionEvent) {
+        reverseGeolocateEvent = event
     }
 }


### PR DESCRIPTION
`MainActivity` now passes all long press events to the `MainPresenter` which decides whether or not to proceed with reverse geocoding based on current view state.

Closes #148