### PR TITLE
Refinements for interacting with map in routing mode

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
@@ -6,13 +6,17 @@ import com.mapzen.valhalla.Instruction
 import com.mapzen.valhalla.Route
 
 public interface RoutePresenter {
+    companion object {
+        public val GESTURE_MIN_DELTA = 0.0001f
+    }
+
     public var routeController: RouteViewController?
     public var currentInstructionIndex: Int
 
     public fun onLocationChanged(location: Location)
     public fun onRouteStart(route: Route?)
     public fun onRouteResume(route: Route?)
-    public fun onMapGesture()
+    public fun onMapGesture(action: Int, pointerCount: Int, deltaX: Float, deltaY: Float)
     public fun onResumeButtonClick()
     public fun onInstructionPagerTouch()
     public fun onInstructionSelected(instruction: Instruction)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.presenter
 
 import android.location.Location
+import android.view.MotionEvent
 import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.helpers.RouteEngine
 import com.mapzen.valhalla.Instruction
@@ -36,9 +37,16 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
         routeController?.setCurrentInstruction(currentInstructionIndex)
     }
 
-    override fun onMapGesture() {
-        isTrackingCurrentLocation = false
-        routeController?.showResumeButton()
+    override fun onMapGesture(action: Int, pointerCount: Int, deltaX: Float, deltaY: Float) {
+        if (action == MotionEvent.ACTION_MOVE) {
+            if (pointerCount == 1) {
+                if (deltaX >= RoutePresenter.GESTURE_MIN_DELTA ||
+                        deltaY >= RoutePresenter.GESTURE_MIN_DELTA) {
+                    isTrackingCurrentLocation = false
+                    routeController?.showResumeButton()
+                }
+            }
+        }
     }
 
     override fun onResumeButtonClick() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -43,7 +43,7 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
     var mapController: MapController? = null
         set(value) {
             value?.setGenericMotionEventListener(View.OnGenericMotionListener {
-                view, event -> onMapMotionEvent()
+                view, event -> onMapMotionEvent(event)
             })
 
             field = value
@@ -274,8 +274,15 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
         }
     }
 
-    private fun onMapMotionEvent(): Boolean {
-        routePresenter?.onMapGesture()
+    private fun onMapMotionEvent(motionEvent: MotionEvent): Boolean {
+        val action = motionEvent.action
+        val pointerCount = motionEvent.pointerCount
+        if (motionEvent.historySize > 0) {
+            val deltaX = motionEvent.getHistoricalX(0)
+            val deltaY = motionEvent.getHistoricalY(0)
+            routePresenter?.onMapGesture(action, pointerCount, deltaX, deltaY)
+        }
+
         mainPresenter?.onMapMotionEvent()
         return false
     }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -64,7 +64,8 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
     private var currentSnapLocation: Location? = null
     private var routeIcon: MapData? = null
     private var routeLine: MapData? = null
-
+    private var previousScrollState: Int = ViewPager.SCROLL_STATE_IDLE
+    private var userScrollChange: Boolean = false
 
     public constructor(context: Context) : super(context) {
         init(context)
@@ -107,11 +108,22 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
         setCurrentPagerItemStyling(routePresenter?.currentInstructionIndex ?: 0);
         val instruction = route?.getRouteInstructions()?.get(position)
         if (instruction is Instruction) {
-            routePresenter?.onInstructionSelected(instruction)
+            if (userScrollChange) {
+                routePresenter?.onInstructionSelected(instruction)
+            }
         }
     }
 
     override fun onPageScrollStateChanged(state: Int) {
+        if (previousScrollState == ViewPager.SCROLL_STATE_DRAGGING
+                && state == ViewPager.SCROLL_STATE_SETTLING) {
+            userScrollChange = true
+        } else if (previousScrollState == ViewPager.SCROLL_STATE_SETTLING
+                && state == ViewPager.SCROLL_STATE_IDLE) {
+            userScrollChange = false
+        }
+
+        previousScrollState = state
     }
 
     public fun setAdapter(adapter: PagerAdapter) {
@@ -356,7 +368,6 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
         val instruction = route?.getRouteInstructions()?.get(index)
         if (instruction is Instruction) {
             voiceNavigationController?.playPost(instruction)
-            routePresenter?.onInstructionSelected(instruction)
         }
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.presenter
 
 import android.location.Location
+import android.view.MotionEvent
 import com.mapzen.erasermap.dummy.TestHelper
 import com.mapzen.erasermap.dummy.TestHelper.getFixture
 import com.mapzen.erasermap.view.TestRouteController
@@ -42,15 +43,40 @@ public class RoutePresenterTest {
 
     @Test fun onMapGesture_shouldShowResumeButton() {
         routeController.isResumeButtonVisible = false
-        routePresenter.onMapGesture()
+        routePresenter.onMapGesture(MotionEvent.ACTION_MOVE, 1, RoutePresenter.GESTURE_MIN_DELTA,
+                RoutePresenter.GESTURE_MIN_DELTA)
         assertThat(routeController.isResumeButtonVisible).isTrue()
     }
 
     @Test fun onMapGesture_shouldDisableLocationTracking() {
         routePresenter.onResumeButtonClick()
-        routePresenter.onMapGesture()
+        routePresenter.onMapGesture(MotionEvent.ACTION_MOVE, 1, RoutePresenter.GESTURE_MIN_DELTA,
+                RoutePresenter.GESTURE_MIN_DELTA)
         routePresenter.onUpdateSnapLocation(Location("test"))
         assertThat(routeController.mapLocation).isNull()
+    }
+
+    @Test fun onMapGesture_shouldNotDisableLocationTrackingOnActionDown() {
+        routePresenter.onResumeButtonClick()
+        routePresenter.onMapGesture(MotionEvent.ACTION_DOWN, 1, RoutePresenter.GESTURE_MIN_DELTA,
+                RoutePresenter.GESTURE_MIN_DELTA)
+        routePresenter.onUpdateSnapLocation(Location("test"))
+        assertThat(routeController.mapLocation).isNotNull()
+    }
+
+    @Test fun onMapGesture_shouldNotDisableLocationTrackingIfMoreThanOnePointer() {
+        routePresenter.onResumeButtonClick()
+        routePresenter.onMapGesture(MotionEvent.ACTION_MOVE, 2, RoutePresenter.GESTURE_MIN_DELTA,
+                RoutePresenter.GESTURE_MIN_DELTA)
+        routePresenter.onUpdateSnapLocation(Location("test"))
+        assertThat(routeController.mapLocation).isNotNull()
+    }
+
+    @Test fun onMapGesture_shouldNotDisableLocationTrackingIfDeltaIsLessThanMinDistance() {
+        routePresenter.onResumeButtonClick()
+        routePresenter.onMapGesture(MotionEvent.ACTION_MOVE, 1, 0f, 0f)
+        routePresenter.onUpdateSnapLocation(Location("test"))
+        assertThat(routeController.mapLocation).isNotNull()
     }
 
     @Test fun onResumeButtonClick_shouldHideResumeButton() {
@@ -60,7 +86,8 @@ public class RoutePresenterTest {
     }
 
     @Test fun onResumeButtonClick_shouldEnableLocationTracking() {
-        routePresenter.onMapGesture()
+        routePresenter.onMapGesture(MotionEvent.ACTION_MOVE, 1, RoutePresenter.GESTURE_MIN_DELTA,
+                RoutePresenter.GESTURE_MIN_DELTA)
         routePresenter.onResumeButtonClick()
         routePresenter.onUpdateSnapLocation(Location("test"))
         assertThat(routeController.mapLocation).isNotNull()


### PR DESCRIPTION
* Track user swipe on view pager vs. programatic changes
* Do not show resume button unless map is moved minimum distance by user
* Do not reset map position to current instruction while user is panning the map

Closes #74 