### PR TITLE
Do not set name in route request for address features

### DIFF
--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -1,7 +1,5 @@
 package com.mapzen.erasermap;
 
-import android.content.Context;
-
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.erasermap.model.AndroidAppSettings;
 import com.mapzen.erasermap.model.AppSettings;
@@ -10,10 +8,14 @@ import com.mapzen.erasermap.model.MapzenLocationImpl;
 import com.mapzen.erasermap.model.RouteManager;
 import com.mapzen.erasermap.model.TileHttpHandler;
 import com.mapzen.erasermap.model.ValhallaRouteManager;
+import com.mapzen.erasermap.model.ValhallaRouterFactory;
 import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
 import com.mapzen.erasermap.presenter.ViewStateManager;
+
 import com.squareup.otto.Bus;
+
+import android.content.Context;
 
 import javax.inject.Singleton;
 
@@ -55,7 +57,8 @@ public class AndroidModule {
     }
 
     @Provides @Singleton RouteManager provideRouteManager(AppSettings settings) {
-        ValhallaRouteManager manager = new ValhallaRouteManager(settings);
+        ValhallaRouteManager manager = new ValhallaRouteManager(settings,
+                new ValhallaRouterFactory());
         if (BuildConfig.VALHALLA_API_KEY != null) {
             manager.setApiKey(BuildConfig.VALHALLA_API_KEY);
         }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/RouterFactory.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/RouterFactory.kt
@@ -1,0 +1,7 @@
+package com.mapzen.erasermap.model
+
+import com.mapzen.valhalla.Router
+
+interface RouterFactory {
+    public fun getRouter(): Router
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
@@ -6,9 +6,8 @@ import com.mapzen.pelias.gson.Feature
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import com.mapzen.valhalla.Router
-import com.mapzen.valhalla.ValhallaRouter
 
-public class ValhallaRouteManager(val settings: AppSettings) : RouteManager {
+public class ValhallaRouteManager(val settings: AppSettings, val routerFactory: RouterFactory) : RouteManager {
     override var apiKey: String = ""
     override var origin: Location? = null
     override var destination: Feature? = null
@@ -36,7 +35,12 @@ public class ValhallaRouteManager(val settings: AppSettings) : RouteManager {
             val start: DoubleArray = doubleArrayOf(location.latitude, location.longitude)
             val dest: DoubleArray = doubleArrayOf(simpleFeature.lat(), simpleFeature.lng())
             val units: Router.DistanceUnits = settings.distanceUnits
-            val name = destination?.properties?.name
+            var name: String? = null
+
+            if (!simpleFeature.isAddress) {
+                name = simpleFeature.name()
+            }
+
             val street = simpleFeature.name()
             val city = simpleFeature.localAdmin()
             val state = simpleFeature.region()
@@ -72,7 +76,7 @@ public class ValhallaRouteManager(val settings: AppSettings) : RouteManager {
     }
 
     private fun getInitializedRouter(type: Router.Type): Router {
-        val router = ValhallaRouter().setApiKey(apiKey)
+        val router = routerFactory.getRouter().setApiKey(apiKey)
         when(type) {
             Router.Type.DRIVING -> return router.setDriving()
             Router.Type.WALKING -> return router.setWalking()

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouterFactory.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouterFactory.kt
@@ -1,0 +1,10 @@
+package com.mapzen.erasermap.model
+
+import com.mapzen.valhalla.Router
+import com.mapzen.valhalla.ValhallaRouter
+
+public class ValhallaRouterFactory : RouterFactory {
+    override fun getRouter(): Router {
+        return ValhallaRouter()
+    }
+}

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouteManager.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouteManager.kt
@@ -3,7 +3,6 @@ package com.mapzen.erasermap.model
 import android.location.Location
 import com.mapzen.erasermap.BuildConfig
 import com.mapzen.pelias.gson.Feature
-import com.mapzen.valhalla.JSON
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import com.mapzen.valhalla.Router
@@ -32,81 +31,12 @@ public class TestRouteManager : RouteManager {
 
     override var apiKey: String = BuildConfig.VALHALLA_API_KEY
 
-    private fun getInitializedRouter(type: Router.Type): Router {
-        return TestRouter()
-    }
-
     public fun reset() {
         locations.clear()
         origin = null
         destination = null
         route = null
         bearing = null
-    }
-
-    public inner class TestRouter : Router {
-        override fun clearLocations(): Router {
-            locations.clear()
-            return this
-        }
-
-        override fun fetch() {
-            isFetching = true
-        }
-
-        override fun getEndpoint(): String {
-            return ""
-        }
-
-        override fun getJSONRequest(): JSON {
-            return JSON()
-        }
-
-        override fun setApiKey(key: String): Router {
-            return this
-        }
-
-        override fun setBiking(): Router {
-            return this
-        }
-
-        override fun setCallback(callback: RouteCallback): Router {
-            return this
-        }
-
-        override fun setDriving(): Router {
-            return this
-        }
-
-        override fun setEndpoint(url: String): Router {
-            return this
-        }
-
-        override fun setLocation(point: DoubleArray): Router {
-            locations.add(point)
-            return this
-        }
-
-        override fun setLocation(point: DoubleArray, heading: Float): Router {
-            locations.add(point)
-            bearing = heading
-            return this
-        }
-
-        override fun setLocation(point: DoubleArray, name: String?,
-                street: String?, city: String?, state: String?): Router {
-            locations.add(point)
-            return this
-        }
-
-        override fun setWalking(): Router {
-            return this
-        }
-
-        override fun setDistanceUnits(units: Router.DistanceUnits): Router {
-            this@TestRouteManager.units = units
-            return this
-        }
     }
 
     public inner class TestRoute : Route(JSONObject()) {

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouter.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouter.kt
@@ -1,0 +1,78 @@
+package com.mapzen.erasermap.model
+
+import com.mapzen.valhalla.JSON
+import com.mapzen.valhalla.RouteCallback
+import com.mapzen.valhalla.Router
+import java.util.ArrayList
+
+public class TestRouter : Router {
+    public var locations: ArrayList<DoubleArray> = ArrayList()
+    public var isFetching: Boolean = false
+    public var units: Router.DistanceUnits = Router.DistanceUnits.MILES
+    public var bearing: Float = 0f
+    public var name: String? = null
+
+    override fun clearLocations(): Router {
+        locations.clear()
+        return this
+    }
+
+    override fun fetch() {
+        isFetching = true
+    }
+
+    override fun getEndpoint(): String {
+        return ""
+    }
+
+    override fun getJSONRequest(): JSON {
+        return JSON()
+    }
+
+    override fun setApiKey(key: String): Router {
+        return this
+    }
+
+    override fun setBiking(): Router {
+        return this
+    }
+
+    override fun setCallback(callback: RouteCallback): Router {
+        return this
+    }
+
+    override fun setDriving(): Router {
+        return this
+    }
+
+    override fun setEndpoint(url: String): Router {
+        return this
+    }
+
+    override fun setLocation(point: DoubleArray): Router {
+        locations.add(point)
+        return this
+    }
+
+    override fun setLocation(point: DoubleArray, heading: Float): Router {
+        locations.add(point)
+        bearing = heading
+        return this
+    }
+
+    override fun setLocation(point: DoubleArray, name: String?, street: String?, city: String?,
+            state: String?): Router {
+        this.name = name
+        locations.add(point)
+        return this
+    }
+
+    override fun setWalking(): Router {
+        return this
+    }
+
+    override fun setDistanceUnits(units: Router.DistanceUnits): Router {
+        this.units = units
+        return this
+    }
+}

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouterFactory.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouterFactory.kt
@@ -1,0 +1,11 @@
+package com.mapzen.erasermap.model
+
+import com.mapzen.valhalla.Router
+
+public class TestRouterFactory : RouterFactory {
+    val router = TestRouter()
+
+    override fun getRouter(): Router {
+        return router
+    }
+}

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
@@ -1,0 +1,41 @@
+package com.mapzen.erasermap.model
+
+import com.mapzen.erasermap.dummy.TestHelper
+import com.mapzen.valhalla.Route
+import com.mapzen.valhalla.RouteCallback
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+public class ValhallaRouteManagerTest {
+    val routerFactory = TestRouterFactory()
+    val routeManager = ValhallaRouteManager(TestAppSettings(), routerFactory)
+
+    @Test fun shouldNotBeNull() {
+        assertThat(routeManager).isNotNull()
+    }
+
+    @Test fun fetchRoute_shouldIncludeNameInRouteRequest() {
+        val feature = TestHelper.getTestFeature()
+        routeManager.origin = TestHelper.getTestLocation()
+        routeManager.destination = feature
+        routeManager.fetchRoute(TestRouteCallback())
+        assertThat(routerFactory.router.name).isEqualTo("Name")
+    }
+
+    @Test fun fetchRoute_shouldNotIncludeNameInRouteRequestIfFeatureIsAnAddress() {
+        val feature = TestHelper.getTestFeature()
+        feature.properties.layer = "address"
+        routeManager.origin = TestHelper.getTestLocation()
+        routeManager.destination = feature
+        routeManager.fetchRoute(TestRouteCallback())
+        assertThat(routerFactory.router.name).isNull()
+    }
+
+    class TestRouteCallback : RouteCallback {
+        override fun failure(statusCode: Int) {
+        }
+
+        override fun success(route: Route) {
+        }
+    }
+}


### PR DESCRIPTION
* Only set name param if a POI name is available.
* Do not set name parameter if the destination is a street address.
* Uses Pelias `layer` field to distinguish address only features.

Closes #137