### PR TITLE
Add settings to enable debug drawing for tiles and labels

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/model/AndroidAppSettings.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/AndroidAppSettings.kt
@@ -15,6 +15,8 @@ public class AndroidAppSettings(val application: EraserMapApplication) : AppSett
         public val KEY_MOCK_LOCATION_VALUE: String = "edittext_mock_location"
         public val KEY_MOCK_ROUTE_ENABLED: String = "checkbox_mock_route"
         public val KEY_MOCK_ROUTE_VALUE: String = "edittext_mock_route"
+        public val KEY_TILE_DEBUG_ENABLED: String = "checkbox_tile_debug"
+        public val KEY_LABEL_DEBUG_ENABLED: String = "checkbox_label_debug"
         public val KEY_BUILD_NUMBER: String = "edittext_build_number"
     }
 
@@ -88,6 +90,28 @@ public class AndroidAppSettings(val application: EraserMapApplication) : AppSett
         }
         set(value) {
             prefs.edit().putString(KEY_MOCK_ROUTE_VALUE, value.getName()).commit()
+        }
+
+    /**
+     * Tile debug drawing checkbox setting
+     */
+    override var isTileDebugEnabled: Boolean
+        get() {
+            return prefs.getBoolean(KEY_TILE_DEBUG_ENABLED, false)
+        }
+        set(value) {
+            prefs.edit().putBoolean(KEY_TILE_DEBUG_ENABLED, value).commit()
+        }
+
+    /**
+     * Label debug drawing checkbox setting
+     */
+    override var isLabelDebugEnabled: Boolean
+        get() {
+            return prefs.getBoolean(KEY_LABEL_DEBUG_ENABLED, false)
+        }
+        set(value) {
+            prefs.edit().putBoolean(KEY_LABEL_DEBUG_ENABLED, value).commit()
         }
 
     init {

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/AndroidAppSettings.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/AndroidAppSettings.kt
@@ -4,6 +4,8 @@ import android.location.Location
 import android.preference.PreferenceManager
 import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
+import com.mapzen.tangram.DebugFlags
+import com.mapzen.tangram.Tangram
 import com.mapzen.valhalla.Router
 import java.io.File
 import java.util.Locale
@@ -124,5 +126,11 @@ public class AndroidAppSettings(val application: EraserMapApplication) : AppSett
                 this.distanceUnits = Router.DistanceUnits.KILOMETERS
             }
         }
+    }
+
+    override fun initTangramDebugFlags() {
+        Tangram.setDebugFlag(DebugFlags.TILE_BOUNDS, isTileDebugEnabled)
+        Tangram.setDebugFlag(DebugFlags.TILE_INFOS, isTileDebugEnabled)
+        Tangram.setDebugFlag(DebugFlags.LABELS, isLabelDebugEnabled)
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/AppSettings.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/AppSettings.kt
@@ -12,4 +12,6 @@ public interface AppSettings {
     public var mockRoute: File
     public var isTileDebugEnabled: Boolean
     public var isLabelDebugEnabled: Boolean
+
+    public fun initTangramDebugFlags()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/AppSettings.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/AppSettings.kt
@@ -10,4 +10,6 @@ public interface AppSettings {
     public var mockLocation: Location
     public var isMockRouteEnabled: Boolean
     public var mockRoute: File
+    public var isTileDebugEnabled: Boolean
+    public var isLabelDebugEnabled: Boolean
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -105,6 +105,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         presenter?.onCreate()
         presenter?.onRestoreViewState()
         supportActionBar?.setDisplayShowTitleEnabled(false)
+        settings?.initTangramDebugFlags()
     }
 
     private fun initMapGestureListener() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SettingsFragment.kt
@@ -7,8 +7,8 @@ import com.mapzen.erasermap.BuildConfig
 import com.mapzen.erasermap.R
 import com.mapzen.erasermap.model.AndroidAppSettings
 import com.mapzen.erasermap.model.AppSettings
-import com.mapzen.tangram.Tangram
 import com.mapzen.tangram.DebugFlags
+import com.mapzen.tangram.Tangram
 
 public class SettingsFragment : PreferenceFragment(), Preference.OnPreferenceChangeListener {
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SettingsFragment.kt
@@ -7,6 +7,8 @@ import com.mapzen.erasermap.BuildConfig
 import com.mapzen.erasermap.R
 import com.mapzen.erasermap.model.AndroidAppSettings
 import com.mapzen.erasermap.model.AppSettings
+import com.mapzen.tangram.Tangram
+import com.mapzen.tangram.DebugFlags
 
 public class SettingsFragment : PreferenceFragment(), Preference.OnPreferenceChangeListener {
 
@@ -26,12 +28,24 @@ public class SettingsFragment : PreferenceFragment(), Preference.OnPreferenceCha
         addPreferencesFromResource(R.xml.preferences)
         initDistanceUnitsPref()
         initBuildNumberPref()
+        initTileDebugPref()
+        initLabelDebugPref()
     }
 
     override fun onPreferenceChange(preference: Preference?, value: Any?): Boolean {
         if (preference is Preference && value is String) {
             if (AndroidAppSettings.KEY_DISTANCE_UNITS.equals(preference.key)) {
                 updateDistanceUnitsPref(preference, value)
+                return true
+            }
+        }
+        if (preference is Preference && value is Boolean) {
+            if (AndroidAppSettings.KEY_TILE_DEBUG_ENABLED.equals(preference.key)) {
+                updateTileDebugPref(value)
+                return true
+            }
+            if (AndroidAppSettings.KEY_LABEL_DEBUG_ENABLED.equals(preference.key)) {
+                updateLabelDebugPref(value)
                 return true
             }
         }
@@ -52,7 +66,27 @@ public class SettingsFragment : PreferenceFragment(), Preference.OnPreferenceCha
         preference.summary = text
     }
 
+    private fun initTileDebugPref() {
+        findPreference(AndroidAppSettings.KEY_TILE_DEBUG_ENABLED).onPreferenceChangeListener = this
+        updateTileDebugPref(settings?.isTileDebugEnabled ?: false)
+    }
+
+    private fun updateTileDebugPref(value: Boolean) {
+        Tangram.setDebugFlag(DebugFlags.TILE_BOUNDS, value)
+        Tangram.setDebugFlag(DebugFlags.TILE_INFOS, value)
+    }
+
+    private fun initLabelDebugPref() {
+        findPreference(AndroidAppSettings.KEY_LABEL_DEBUG_ENABLED).onPreferenceChangeListener = this
+        updateLabelDebugPref(settings?.isLabelDebugEnabled ?: false)
+    }
+
+    private fun updateLabelDebugPref(value: Boolean) {
+        Tangram.setDebugFlag(DebugFlags.LABELS, value)
+    }
+
     private fun initBuildNumberPref() {
         findPreference(AndroidAppSettings.KEY_BUILD_NUMBER).summary = BuildConfig.BUILD_NUMBER
     }
+
 }

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -30,6 +30,14 @@
     <string name="edittext_mock_route_summary">Path to GPX trace file (SD card)</string>
     <string name="edittext_mock_route_title">Set mock route</string>
 
+    <!-- Enable tile debug rendering -->
+    <string name="checkbox_tile_debug_summary">Draw map tile debugging information</string>
+    <string name="checkbox_tile_debug_title">Tile debug info</string>
+
+    <!-- Enable label debug rendering -->
+    <string name="checkbox_label_debug_summary">Draw label debugging information</string>
+    <string name="checkbox_label_debug_title">Label debug info</string>
+
     <!-- Build number -->
     <string name="edittext_build_number_title">Build number</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -38,6 +38,16 @@
             android:summary="@string/edittext_mock_route_summary"
             android:title="@string/edittext_mock_route_title" />
 
+        <CheckBoxPreference
+            android:key="checkbox_tile_debug"
+            android:summary="@string/checkbox_tile_debug_summary"
+            android:title="@string/checkbox_tile_debug_title" />
+
+        <CheckBoxPreference
+            android:key="checkbox_label_debug"
+            android:summary="@string/checkbox_label_debug_summary"
+            android:title="@string/checkbox_label_debug_title" />
+
         <com.mapzen.erasermap.view.ReadOnlyPreference
             android:key="edittext_build_number"
             android:title="@string/edittext_build_number_title" />

--- a/app/src/test/java/com/mapzen/erasermap/shadows/ShadowTangram.java
+++ b/app/src/test/java/com/mapzen/erasermap/shadows/ShadowTangram.java
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.shadows;
 
 import com.mapzen.tangram.DataSource;
+import com.mapzen.tangram.DebugFlags;
 import com.mapzen.tangram.Tangram;
 
 import org.robolectric.annotation.Implementation;
@@ -8,18 +9,29 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.shadows.ShadowSurfaceView;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 
 @Implements(Tangram.class)
 public class ShadowTangram extends ShadowSurfaceView {
     public static ArrayList<DataSource> dataSources = new ArrayList<>();
+    public static HashSet<DebugFlags> debugFlags = new HashSet<>();
 
     @Implementation
-    public static void addDataSource(DataSource source) {
-        dataSources.add(source);
+    public static void addDataSource(DataSource _source) {
+        dataSources.add(_source);
     }
 
     @Implementation
-    public static void clearDataSource(DataSource source, boolean data, boolean tiles) {
-        dataSources.remove(source);
+    public static void clearDataSource(DataSource _source, boolean _data, boolean _tiles) {
+        dataSources.remove(_source);
+    }
+
+    @Implementation
+    public static void setDebugFlag(DebugFlags _flag, boolean _on) {
+        if (_on) {
+            debugFlags.add(_flag);
+        } else {
+            debugFlags.remove(_flag);
+        }
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/AndroidAppSettingsTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/AndroidAppSettingsTest.kt
@@ -5,6 +5,8 @@ import com.mapzen.erasermap.BuildConfig
 import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.PrivateMapsTestRunner
 import com.mapzen.erasermap.dummy.TestHelper
+import com.mapzen.erasermap.shadows.ShadowTangram
+import com.mapzen.tangram.DebugFlags
 import com.mapzen.valhalla.Router
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -158,5 +160,14 @@ public class AndroidAppSettingsTest {
         val key = AndroidAppSettings.KEY_MOCK_ROUTE_VALUE
         settings.mockRoute = File("ymca.gpx")
         assertThat(prefs.getString(key, null)).isEqualTo("ymca.gpx")
+    }
+
+    @Test fun initTangramDebugFlags_shouldSetTangramDebugFlags() {
+        prefs.edit().putBoolean(AndroidAppSettings.KEY_TILE_DEBUG_ENABLED, true).commit()
+        prefs.edit().putBoolean(AndroidAppSettings.KEY_LABEL_DEBUG_ENABLED, true).commit()
+        settings.initTangramDebugFlags()
+        assertThat(ShadowTangram.debugFlags).contains(DebugFlags.TILE_BOUNDS)
+        assertThat(ShadowTangram.debugFlags).contains(DebugFlags.TILE_INFOS)
+        assertThat(ShadowTangram.debugFlags).contains(DebugFlags.LABELS)
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestAppSettings.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestAppSettings.kt
@@ -13,4 +13,7 @@ public class TestAppSettings : AppSettings {
     override var mockRoute: File = File("lost.gpx")
     override var isTileDebugEnabled: Boolean = false
     override var isLabelDebugEnabled: Boolean = false
+
+    override fun initTangramDebugFlags() {
+    }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestAppSettings.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestAppSettings.kt
@@ -11,4 +11,6 @@ public class TestAppSettings : AppSettings {
     override var mockLocation: Location = TestHelper.getTestLocation()
     override var isMockRouteEnabled: Boolean = false
     override var mockRoute: File = File("lost.gpx")
+    override var isTileDebugEnabled: Boolean = false
+    override var isLabelDebugEnabled: Boolean = false
 }

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -9,4 +9,5 @@
     <suppress checks="MagicNumberCheck" files=".*src/test/java/*" />
     <suppress checks="[a-zA-Z0-9]*" files="MapzenAndroidManifest\.java" />
     <suppress checks="VisibilityModifier" files="ShadowTangram\.java" />
+    <suppress checks="ParameterName" files="ShadowTangram\.java" />
 </suppressions>


### PR DESCRIPTION
This is mostly to aid in style evaluation and debugging. With tile debug info enabled, the boundaries and coordinates (x, y, zoom) of each tile is made visible. With label debug info enabled, anchor points and bounding boxes for each label are made visible. 

I considered making this a single toggle but the label debug drawing is quite slow and usually not needed. Remaining nitpicks:

 - ~~Settings aren't applied until the settings menu is opened (i.e. until a `SettingsFragment` is created); not sure how to fix this most simply.~~ (Thanks Chuck!)
 - Tile debug info is only applied to new tiles, not already-rendered tiles. This is really a thing that's best fixed within Tangram-ES, so I'll take care of that there. 

Closes #167 