### PR TITLE
Improved verbal instructions on route start and reroute

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -92,7 +92,7 @@ dependencies {
   compile 'com.android.support:appcompat-v7:22.2.0'
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   compile 'com.mapzen.tangram:tangram:0.1-SNAPSHOT'
-  compile 'com.mapzen.android:lost:1.0.1'
+  compile 'com.mapzen.android:lost:1.0.2-SNAPSHOT'
   compile('com.mapzen.android:pelias-android-sdk:0.7-SNAPSHOT') {
     exclude group: 'javax.annotation:javax', module: 'javax.annotation-api'
   }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RouteEngineListener.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RouteEngineListener.kt
@@ -14,6 +14,12 @@ class RouteEngineListener : RouteListener {
     public var controller: RouteViewController? = null
     public var debug: Boolean = true
 
+    override fun onRouteStart() {
+        log("[onRouteStart]")
+        controller?.setCurrentInstruction(0)
+        controller?.playPreInstructionAlert(0)
+    }
+
     override fun onSnapLocation(originalLocation: Location, snapLocation: Location) {
         log("[onSnapLocation]", "original = $originalLocation | snap = $snapLocation")
         controller?.updateSnapLocation(snapLocation);
@@ -33,7 +39,9 @@ class RouteEngineListener : RouteListener {
 
     override fun onInstructionComplete(index: Int) {
         log("[onInstructionComplete]", index)
-        controller?.playPostInstructionAlert(index)
+        if (index != 0) {
+            controller?.playPostInstructionAlert(index)
+        }
     }
 
     override fun onUpdateDistance(next: Int, destination: Int) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -27,10 +27,10 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
 
     override fun onRouteStart(route: Route?) {
         this.route = route
-        routeEngine.route = route
         routeEngine.setListener(routeEngineListener)
         currentInstructionIndex = 0
         routeController?.setCurrentInstruction(0)
+        routeEngine.route = route
     }
 
     override fun onRouteResume(route: Route?) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -106,6 +106,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         presenter?.onRestoreViewState()
         supportActionBar?.setDisplayShowTitleEnabled(false)
         settings?.initTangramDebugFlags()
+        routeModeView.voiceNavigationController = VoiceNavigationController(this)
     }
 
     private fun initMapGestureListener() {
@@ -603,7 +604,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         routeModeView.mainPresenter = presenter
         routeModeView.mapController = mapController
         presenter?.routeViewController = routeModeView
-        routeModeView.voiceNavigationController = VoiceNavigationController(this)
     }
 
     override fun hideRoutingMode() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -384,6 +384,11 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
         }
     }
 
+    override fun playStartInstructionAlert() {
+        val instruction = route?.getRouteInstructions()?.get(0)
+        if (instruction is Instruction) voiceNavigationController?.playStart(instruction)
+    }
+
     override fun playPreInstructionAlert(index: Int) {
         val instruction = route?.getRouteInstructions()?.get(index)
         if (instruction is Instruction) voiceNavigationController?.playPre(instruction)
@@ -424,6 +429,7 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
     }
 
     override fun showReroute(location: Location) {
+        voiceNavigationController?.playRecalculating()
         mainPresenter?.onReroute(location)
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteViewController.kt
@@ -16,6 +16,7 @@ public interface RouteViewController {
     public fun updateSnapLocation(location: Location)
     public fun setCurrentInstruction(index: Int)
     public fun setMilestone(index: Int, milestone: RouteEngine.Milestone)
+    public fun playStartInstructionAlert()
     public fun playPreInstructionAlert(index: Int)
     public fun playPostInstructionAlert(index: Int)
     public fun updateDistanceToNextInstruction(meters: Int)

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/VoiceNavigationController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/VoiceNavigationController.kt
@@ -15,6 +15,14 @@ public class VoiceNavigationController(val activity: Activity) {
         speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD)
     }
 
+    public fun playStart(instruction: Instruction): Unit =
+        play(instruction.getVerbalPreTransitionInstruction())
+
+    public fun playRecalculating() {
+        speakerbox.textToSpeech.stop()
+        play(activity.getString(R.string.recalculating))
+    }
+
     public fun playMilestone(instruction: Instruction,
             milestone: RouteEngine.Milestone,
             units: Router.DistanceUnits) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="milestone_half_km">In a half kilometer</string>
 
     <string name="less_than_one_minute">&lt;1 min</string>
+    <string name="recalculating">Recalculating</string>
 </resources>

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/MapzenLocationTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/MapzenLocationTest.kt
@@ -63,6 +63,23 @@ public class MapzenLocationTest {
         assertThat(mapzenLocation.getLastLocation()).isNull()
     }
 
+    @Test fun onLocationUpdate_shouldPostOneEvent() {
+        val subscriber = LocationChangeSubscriber()
+        bus.register(subscriber)
+        mapzenLocation.onLocationUpdate(TestHelper.getTestLocation())
+        assertThat(subscriber.event?.location).isNotNull()
+    }
+
+    @Test fun onLocationUpdate_shouldNotPostEventIfDistanceIsLessThanMinimumDisplacement() {
+        val location1 = TestHelper.getTestLocation(0.0, 0.0)
+        val location2 = TestHelper.getTestLocation(0.0, 0.0)
+        val subscriber = LocationChangeSubscriber()
+        bus.register(subscriber)
+        mapzenLocation.onLocationUpdate(location1)
+        mapzenLocation.onLocationUpdate(location2)
+        assertThat(subscriber.event?.location).isSameAs(location1)
+    }
+
     class LocationChangeSubscriber {
         public var event: LocationChangeEvent? = null
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RouteEngineListenerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RouteEngineListenerTest.kt
@@ -16,4 +16,14 @@ class RouteEngineListenerTest {
     @Test fun shouldNotBeNull() {
         assertThat(routeListener).isNotNull()
     }
+
+    @Test fun onInstructionComplete_shouldPlayPostInstruction() {
+        routeListener.onInstructionComplete(1)
+        assertThat(routeController.post).isEqualTo(1)
+    }
+
+    @Test fun onInstructionComplete_shouldNotPlayPostInstructionWhenIndexIsZero() {
+        routeListener.onInstructionComplete(0)
+        assertThat(routeController.post).isEqualTo(-1)
+    }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -28,6 +28,7 @@ public class RoutePresenterTest {
     @Test fun onRouteStart_shouldResetRouteEngine() {
         val route1 = Route(getFixture("valhalla_route"))
         val route2 = Route(getFixture("valhalla_route"))
+        routeEngine.setListener(routeListener)
         routeEngine.route = route1
         routePresenter.onRouteStart(route2)
         assertThat(routeEngine.route).isEqualTo(route2)
@@ -36,6 +37,7 @@ public class RoutePresenterTest {
     @Test fun onRouteResume_shouldNotResetRouteEngine() {
         val route1 = Route(getFixture("valhalla_route"))
         val route2 = Route(getFixture("valhalla_route"))
+        routeEngine.setListener(routeListener)
         routeEngine.route = route1
         routePresenter.onRouteResume(route2)
         assertThat(routeEngine.route).isEqualTo(route1)

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
@@ -10,6 +10,9 @@ public class TestRouteController : RouteViewController {
     public var isResumeButtonVisible: Boolean = false
     public var isRouteIconVisible: Boolean = false
     public var isRouteLineVisible: Boolean = false
+    public var alert: Int = -1
+    public var pre: Int = -1
+    public var post: Int = -1
 
     override fun onLocationChanged(location: Location) {
         this.location = location
@@ -48,12 +51,15 @@ public class TestRouteController : RouteViewController {
     }
 
     override fun setMilestone(index: Int, milestone: RouteEngine.Milestone) {
+        alert = index
     }
 
     override fun playPreInstructionAlert(index: Int) {
+        pre = index
     }
 
     override fun playPostInstructionAlert(index: Int) {
+        post = index
     }
 
     override fun updateDistanceToNextInstruction(meters: Int) {

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
@@ -84,4 +84,7 @@ public class TestRouteController : RouteViewController {
     override fun hideRouteLine() {
         isRouteLineVisible = false
     }
+
+    override fun playStartInstructionAlert() {
+    }
 }


### PR DESCRIPTION
Prevents reroute loops and ensures first verbal instruction is played. Adds "recalculating" verbal alert on reroute.

* Updates LOST to version 1.0.2-SNAPSHOT to include bearing in mock routes.
* Adds minimum displacement for location updates (also reduces map jitter in routing mode).
* Clears TTS queue and plays verbal "recalculating" message on reroute.
* Plays starting instruction as soon as route is set (no longer waits for first location update).
* Initializes TTS engine when `MainActivity` is created to prevent lag when playing first instruction.

Depends on https://github.com/mapzen/on-the-road/pull/52

Closes #213
Closes #111 
