### PR TITLE
Add search feature state property

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -112,6 +112,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
     override fun onSearchResultSelected(position: Int) {
         if (searchResults != null) {
+            mainViewController?.addSearchResultsToMap(searchResults?.getFeatures(), position)
             mainViewController?.centerOnCurrentFeature(searchResults?.features)
         }
     }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -351,7 +351,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
 
     override fun showSearchResults(features: List<Feature>) {
         showSearchResultsPager(features)
-        addSearchResultsToMap(features)
+        addSearchResultsToMap(features, 0)
     }
 
     private fun showSearchResultsPager(features: List<Feature>) {
@@ -368,7 +368,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         pager.onSearchResultsSelectedListener = this
     }
 
-    private fun addSearchResultsToMap(features: List<Feature>) {
+    override fun addSearchResultsToMap(features: List<Feature>, activeIndex: Int) {
         centerOnCurrentFeature(features)
 
         if (searchResults == null) {
@@ -376,14 +376,21 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
             Tangram.addDataSource(searchResults);
         }
 
+        var activeFeature: Int = 0
         searchResults?.clear()
         for (feature in features) {
             val simpleFeature = SimpleFeature.fromFeature(feature)
             val lngLat = LngLat(simpleFeature.lng(), simpleFeature.lat())
             val properties = com.mapzen.tangram.Properties()
             properties.add("type", "point");
+            if (activeFeature == activeIndex) {
+                properties.add("state", "active");
+            } else {
+                properties.add("state", "inactive");
+            }
 
             searchResults?.addPoint(properties, lngLat)
+            activeFeature++;
         }
         mapController?.requestRender()
     }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
@@ -7,6 +7,7 @@ import com.mapzen.valhalla.Route
 
 public interface MainViewController {
     public fun showSearchResults(features: List<Feature>)
+    public fun addSearchResultsToMap(features: List<Feature>, activeIndex: Int)
     public fun showDirectionList()
     public fun centerOnCurrentFeature(features: List<Feature>)
     public fun showAllSearchResults(features: List<Feature>)

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
@@ -30,6 +30,10 @@ public class TestMainController : MainViewController {
         searchResults = features
     }
 
+    override fun addSearchResultsToMap(features: List<Feature>, activeIndex: Int) {
+        searchResults = features;
+    }
+
     override fun centerOnCurrentFeature(features: List<Feature>) {
         isCenteredOnCurrentFeature = true
     }


### PR DESCRIPTION
- Since `tangram-es` API does not provide way to modify feature properties for a `MapData`, we need to rebuild `searchResults` `MapData` everytime active search feature changes.
- By default 1st feature in the search results is marked active.

Fixes #133