### PR TITLE
Disallow reverseGeo on an active search

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -394,9 +394,9 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     }
 
     override fun showSearchResults(features: List<Feature>) {
+        hideReverseGeolocateResult()
         showSearchResultsPager(features)
         addSearchResultsToMap(features, 0)
-        hideReverseGeolocateResult()
     }
 
     private fun showSearchResultsPager(features: List<Feature>) {


### PR DESCRIPTION
- Disallow ReveserGeo on an active search
- also fixes an issue with onBackPress when ViewState was ROUTING_PREVIEW. (Should not clear the previous search results)

Fixes #252 
Fixes #251 