### PR TITLE
Add debug toggle for misc tangram debug infos

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/model/AndroidAppSettings.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/AndroidAppSettings.kt
@@ -19,6 +19,7 @@ public class AndroidAppSettings(val application: EraserMapApplication) : AppSett
         public val KEY_MOCK_ROUTE_VALUE: String = "edittext_mock_route"
         public val KEY_TILE_DEBUG_ENABLED: String = "checkbox_tile_debug"
         public val KEY_LABEL_DEBUG_ENABLED: String = "checkbox_label_debug"
+        public val KEY_TANGRAM_INFOS_DEBUG_ENABLED: String = "checkbox_tangram_infos_debug"
         public val KEY_BUILD_NUMBER: String = "edittext_build_number"
     }
 
@@ -106,6 +107,17 @@ public class AndroidAppSettings(val application: EraserMapApplication) : AppSett
         }
 
     /**
+     * Tangram infos debug drawing checkbox setting
+     */
+    override var isTangramInfosDebugEnabled: Boolean
+        get() {
+            return prefs.getBoolean(KEY_TANGRAM_INFOS_DEBUG_ENABLED, false)
+        }
+        set(value) {
+            prefs.edit().putBoolean(KEY_TANGRAM_INFOS_DEBUG_ENABLED, value).commit()
+        }
+
+    /**
      * Label debug drawing checkbox setting
      */
     override var isLabelDebugEnabled: Boolean
@@ -132,5 +144,6 @@ public class AndroidAppSettings(val application: EraserMapApplication) : AppSett
         Tangram.setDebugFlag(DebugFlags.TILE_BOUNDS, isTileDebugEnabled)
         Tangram.setDebugFlag(DebugFlags.TILE_INFOS, isTileDebugEnabled)
         Tangram.setDebugFlag(DebugFlags.LABELS, isLabelDebugEnabled)
+        Tangram.setDebugFlag(DebugFlags.TANGRAM_INFOS, isTangramInfosDebugEnabled)
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/AppSettings.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/AppSettings.kt
@@ -12,6 +12,7 @@ public interface AppSettings {
     public var mockRoute: File
     public var isTileDebugEnabled: Boolean
     public var isLabelDebugEnabled: Boolean
+    public var isTangramInfosDebugEnabled: Boolean
 
     public fun initTangramDebugFlags()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SettingsFragment.kt
@@ -30,6 +30,7 @@ public class SettingsFragment : PreferenceFragment(), Preference.OnPreferenceCha
         initBuildNumberPref()
         initTileDebugPref()
         initLabelDebugPref()
+        initTangramInfosDebugPref()
     }
 
     override fun onPreferenceChange(preference: Preference?, value: Any?): Boolean {
@@ -46,6 +47,10 @@ public class SettingsFragment : PreferenceFragment(), Preference.OnPreferenceCha
             }
             if (AndroidAppSettings.KEY_LABEL_DEBUG_ENABLED.equals(preference.key)) {
                 updateLabelDebugPref(value)
+                return true
+            }
+            if (AndroidAppSettings.KEY_TANGRAM_INFOS_DEBUG_ENABLED.equals(preference.key)) {
+                updateTangramInfosDebugPref(value)
                 return true
             }
         }
@@ -74,6 +79,15 @@ public class SettingsFragment : PreferenceFragment(), Preference.OnPreferenceCha
     private fun updateTileDebugPref(value: Boolean) {
         Tangram.setDebugFlag(DebugFlags.TILE_BOUNDS, value)
         Tangram.setDebugFlag(DebugFlags.TILE_INFOS, value)
+    }
+
+    private fun initTangramInfosDebugPref() {
+        findPreference(AndroidAppSettings.KEY_TANGRAM_INFOS_DEBUG_ENABLED).onPreferenceChangeListener = this
+        updateTangramInfosDebugPref(settings?.isTileDebugEnabled ?: false)
+    }
+
+    private fun updateTangramInfosDebugPref(value: Boolean) {
+        Tangram.setDebugFlag(DebugFlags.TANGRAM_INFOS, value)
     }
 
     private fun initLabelDebugPref() {

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -38,6 +38,10 @@
     <string name="checkbox_label_debug_summary">Draw label debugging information</string>
     <string name="checkbox_label_debug_title">Label debug info</string>
 
+    <!-- Enable tangram infos debug rendering -->
+    <string name="checkbox_tangram_infos_summary">Draw misc tangram debugging information</string>
+    <string name="checkbox_tangram_infos_debug">Tangram debug info</string>
+
     <!-- Build number -->
     <string name="edittext_build_number_title">Build number</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -48,6 +48,11 @@
             android:summary="@string/checkbox_label_debug_summary"
             android:title="@string/checkbox_label_debug_title" />
 
+        <CheckBoxPreference
+            android:key="checkbox_tangram_infos_debug"
+            android:summary="@string/checkbox_tangram_infos_summary"
+            android:title="@string/checkbox_tangram_infos_debug" />
+
         <com.mapzen.erasermap.view.ReadOnlyPreference
             android:key="edittext_build_number"
             android:title="@string/edittext_build_number_title" />

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/AndroidAppSettingsTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/AndroidAppSettingsTest.kt
@@ -165,9 +165,11 @@ public class AndroidAppSettingsTest {
     @Test fun initTangramDebugFlags_shouldSetTangramDebugFlags() {
         prefs.edit().putBoolean(AndroidAppSettings.KEY_TILE_DEBUG_ENABLED, true).commit()
         prefs.edit().putBoolean(AndroidAppSettings.KEY_LABEL_DEBUG_ENABLED, true).commit()
+        prefs.edit().putBoolean(AndroidAppSettings.KEY_TANGRAM_INFOS_DEBUG_ENABLED, true).commit()
         settings.initTangramDebugFlags()
         assertThat(ShadowTangram.debugFlags).contains(DebugFlags.TILE_BOUNDS)
         assertThat(ShadowTangram.debugFlags).contains(DebugFlags.TILE_INFOS)
         assertThat(ShadowTangram.debugFlags).contains(DebugFlags.LABELS)
+        assertThat(ShadowTangram.debugFlags).contains(DebugFlags.TANGRAM_INFOS)
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestAppSettings.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestAppSettings.kt
@@ -13,6 +13,7 @@ public class TestAppSettings : AppSettings {
     override var mockRoute: File = File("lost.gpx")
     override var isTileDebugEnabled: Boolean = false
     override var isLabelDebugEnabled: Boolean = false
+    override var isTangramInfosDebugEnabled: Boolean = false
 
     override fun initTangramDebugFlags() {
     }


### PR DESCRIPTION
Precise zoom display requested from https://github.com/mapzen/eraser-map/issues/167 with more misc tangram infos printout (current lat/lon, tile cache size, visible tiles, frame time, ...) from https://github.com/tangrams/tangram-es/pull/493