### PR TITLE
Disable reverse geo in route preview mode

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -150,6 +150,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
     @Subscribe public fun onRoutePreviewEvent(event: RoutePreviewEvent) {
         vsm.viewState = ViewStateManager.ViewState.ROUTE_PREVIEW
+        reverseGeo = false
         destination = event.destination
         mainViewController?.collapseSearchView()
         mainViewController?.hideSearchResults()

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -188,6 +188,12 @@ public class MainPresenterTest {
         assertThat(mainController.isRoutePreviewVisible).isTrue()
     }
 
+    @Test fun onRoutePreviewEvent_shouldDisableReverseGeocode() {
+        presenter.onReverseGeoRequested(0f, 0f)
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        assertThat(presenter.onReverseGeoRequested(0f, 0f)).isFalse()
+    }
+
     @Test fun onBackPressed_shouldHideRoutePreview() {
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
         presenter.onBackPressed()


### PR DESCRIPTION
Once route preview is initiated clears reverse geo flag to prevent long press and poi tapping. Also fixes in routing mode.

Fixes #271
Fixes #276