### PR TITLE
Restore view state based on VSM

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -9,6 +9,12 @@ import com.mapzen.erasermap.model.event.LocationChangeEvent
 import com.mapzen.erasermap.model.event.RouteCancelEvent
 import com.mapzen.erasermap.model.event.RouteEvent
 import com.mapzen.erasermap.model.event.RoutePreviewEvent
+import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.DEFAULT
+import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTE_DIRECTION_LIST
+import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTE_PREVIEW
+import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTING
+import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.SEARCH
+import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.SEARCH_RESULTS
 import com.mapzen.erasermap.view.MainViewController
 import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.pelias.PeliasLocationProvider
@@ -86,7 +92,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
             val current = searchResults?.features?.get(0)
             if (current is Feature) {
                 features.add(current)
-                mainViewController?.overridePlaceFeature(features?.get(0))
+                mainViewController?.overridePlaceFeature(features.get(0))
             }
             searchResults?.features = features
             mainViewController?.showPlaceSearchFeature(features)
@@ -94,21 +100,41 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     }
 
     override fun onRestoreViewState() {
-        if (destination != null) {
-            if(routingEnabled) {
-                resumeRoutingMode()
-            } else {
-                generateRoutePreview()
-            }
-        } else {
-            if (searchResults != null) {
-                mainViewController?.showSearchResults(searchResults?.features)
-            }
+        when (vsm.viewState) {
+            DEFAULT -> onRestoreViewStateDefault()
+            SEARCH -> onRestoreViewStateSearch()
+            SEARCH_RESULTS -> onRestoreViewStateSearchResults()
+            ROUTE_PREVIEW -> onRestoreViewStateRoutePreview()
+            ROUTING -> onRestoreViewStateRouting()
+            ROUTE_DIRECTION_LIST -> onRestoreViewStateRouteDirectionList()
         }
+   }
 
-        if (vsm.viewState == ViewStateManager.ViewState.ROUTE_DIRECTION_LIST) {
-            routeViewController?.showRouteDirectionList()
+    private fun onRestoreViewStateDefault() {
+        // Do nothing.
+    }
+
+    private fun onRestoreViewStateSearch() {
+        // Do nothing.
+    }
+
+    private fun onRestoreViewStateSearchResults() {
+        if (searchResults?.features != null) {
+            mainViewController?.showSearchResults(searchResults?.features)
         }
+    }
+
+    private fun onRestoreViewStateRoutePreview() {
+        generateRoutePreview()
+    }
+
+    private fun onRestoreViewStateRouting() {
+        resumeRoutingMode()
+    }
+
+    private fun onRestoreViewStateRouteDirectionList() {
+        resumeRoutingMode()
+        routeViewController?.showRouteDirectionList()
     }
 
     override fun onExpandSearchView() {
@@ -164,12 +190,12 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
     override fun onBackPressed() {
         when (vsm.viewState) {
-            ViewStateManager.ViewState.DEFAULT -> onBackPressedStateDefault()
-            ViewStateManager.ViewState.SEARCH -> onBackPressedStateSearch()
-            ViewStateManager.ViewState.SEARCH_RESULTS -> onBackPressedStateSearchResults()
-            ViewStateManager.ViewState.ROUTE_PREVIEW -> onBackPressedStateRoutePreview()
-            ViewStateManager.ViewState.ROUTING -> onBackPressedStateRouting()
-            ViewStateManager.ViewState.ROUTE_DIRECTION_LIST -> onBackPressedStateRouteDirectionList()
+            DEFAULT -> onBackPressedStateDefault()
+            SEARCH -> onBackPressedStateSearch()
+            SEARCH_RESULTS -> onBackPressedStateSearchResults()
+            ROUTE_PREVIEW -> onBackPressedStateRoutePreview()
+            ROUTING -> onBackPressedStateRouting()
+            ROUTE_DIRECTION_LIST -> onBackPressedStateRouteDirectionList()
         }
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestMapzenLocation.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestMapzenLocation.kt
@@ -1,9 +1,9 @@
 package com.mapzen.erasermap.model
 
 import android.location.Location
-import com.mapzen.erasermap.dummy.TestHelper
 import com.mapzen.pelias.BoundingBox
 import com.mapzen.tangram.MapController
+import org.mockito.Mockito
 
 public class TestMapzenLocation : MapzenLocation {
     public var connected = false
@@ -19,7 +19,7 @@ public class TestMapzenLocation : MapzenLocation {
     }
 
     override fun getLastLocation(): Location? {
-        return TestHelper.getTestLocation()
+        return Mockito.mock(Location::class.java)
     }
 
     override fun getLon(): Double {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -50,7 +50,7 @@ public class MainPresenterTest {
     @Test fun onSearchResultsAvailable_shouldShowSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()
-        result.setFeatures(features)
+        result.features = features
         presenter.onSearchResultsAvailable(result)
         assertThat(mainController.searchResults).isEqualTo(features)
     }
@@ -58,7 +58,7 @@ public class MainPresenterTest {
     @Test fun onReverseGeocodeResultsAvailable_shouldShowSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()
-        result.setFeatures(features)
+        result.features = features
         presenter.onReverseGeocodeResultsAvailable(result)
         assertThat(mainController.isReverseGeocodeVisible).isTrue()
     }
@@ -66,7 +66,7 @@ public class MainPresenterTest {
     @Test fun onPlaceSearchResultsAvailable_shouldShowSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()
-        result.setFeatures(features)
+        result.features = features
         presenter.onPlaceSearchResultsAvailable(result)
         assertThat(mainController.isReverseGeocodeVisible).isTrue()
     }
@@ -76,7 +76,7 @@ public class MainPresenterTest {
         val features = ArrayList<Feature>()
         val feature = Feature()
         features.add(feature)
-        result.setFeatures(features)
+        result.features = features
         presenter.onPlaceSearchResultsAvailable(result)
         assertThat(mainController.isReverseGeocodeVisible).isTrue()
     }
@@ -86,7 +86,7 @@ public class MainPresenterTest {
         val features = ArrayList<Feature>()
         val feature = Feature()
         features.add(feature)
-        result.setFeatures(features)
+        result.features = features
         presenter.onPlaceSearchResultsAvailable(result)
         assertThat(mainController.isPlaceResultOverridden).isTrue()
     }
@@ -94,7 +94,7 @@ public class MainPresenterTest {
     @Test fun onRestoreViewState_shouldRestorePreviousSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()
-        result.setFeatures(features)
+        result.features = features
         presenter.onSearchResultsAvailable(result)
 
         val newController = TestMainController()
@@ -113,6 +113,7 @@ public class MainPresenterTest {
 
     @Test fun onRestoreViewState_shouldShowRoutingMode() {
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.vsm.viewState = ROUTING
         val newController = TestMainController()
         presenter.mainViewController = newController
         presenter.routingEnabled = true
@@ -120,10 +121,19 @@ public class MainPresenterTest {
         assertThat(newController.isRoutingModeVisible).isTrue()
     }
 
+    @Test fun onRestoreViewState_shouldNotTriggerRoutePreviewIfNotCorrectViewState() {
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onBackPressed()
+        val newController = TestMainController()
+        presenter.mainViewController = newController
+        presenter.onRestoreViewState()
+        assertThat(newController.isRoutePreviewVisible).isFalse()
+    }
+
     @Test fun onCollapseSearchView_shouldHideSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()
-        result.setFeatures(features)
+        result.features = features
         presenter.onSearchResultsAvailable(result)
         presenter.onCollapseSearchView()
         assertThat(mainController.searchResults).isNull()
@@ -238,7 +248,7 @@ public class MainPresenterTest {
     @Test fun onSearchResultSelected_shouldCenterOnCurrentFeature() {
         val result = Result()
         val features = ArrayList<Feature>()
-        result.setFeatures(features)
+        result.features = features
         presenter.onSearchResultsAvailable(result)
         presenter.onSearchResultSelected(0)
         assertThat(mainController.isCenteredOnCurrentFeature).isTrue()
@@ -247,7 +257,7 @@ public class MainPresenterTest {
     @Test fun onSearchResultTapped_shouldCenterOnCurrentFeature() {
         val result = Result()
         val features = ArrayList<Feature>()
-        result.setFeatures(features)
+        result.features = features
         presenter.onSearchResultsAvailable(result)
         presenter.onSearchResultTapped(0)
         assertThat(mainController.isCenteredOnTappedFeature).isTrue()


### PR DESCRIPTION
Revises logic in `MainPresenter#onRestoreViewState()` to use `ViewStateManager` to dictate which views should be shown and/or hidden when the activity is recreated. Prevents getting stuck in route preview mode when resuming the app once and for all (I hope).

Tacked on some code cleanup including static import of view states and Kotlin property access syntax.

Fixes #276 