### PR TITLE
Be more aggressive in clearing gl resources

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -186,6 +186,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
 
     private fun initMapController() {
         val mapView = findViewById(R.id.map) as MapView
+        mapView.setPreserveEGLContextOnPause(false)
         mapController = MapController(this, mapView, "style/eraser-map.yaml")
         mapController?.setLongPressResponder({
             x, y -> presenter?.onReverseGeoRequested(x, y)


### PR DESCRIPTION
- This will make tangram clear its gl resources whenever the app is backgrounded.
- Possibly will not make android kill eraser-map activity that often when other applications are fighting for resources.

cc. @blair1618 @ecgreb 