### PR TITLE
Custom search view

### DIFF
--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -2,22 +2,15 @@
     xmlns:app="http://schemas.android.com/apk/res/com.mapzen.erasermap">
 
     <item
-        android:id="@+id/action_search"
-        android:icon="@drawable/ic_search"
-        android:title="@string/action_search"
-        app:showAsAction="always"
-        app:actionViewClass="com.mapzen.pelias.widget.PeliasSearchView" />
-
-    <item
         android:id="@+id/action_view_all"
         android:title="@string/action_view_all"
         android:icon="@drawable/ic_list"
         android:visible="false"
         app:showAsAction="always" />
 
-        <item
-            android:id="@+id/action_settings"
-            android:title="@string/action_settings"
-            android:icon="@drawable/ic_settings"
-            app:showAsAction="always" />
+    <item
+        android:id="@+id/action_settings"
+        android:title="@string/action_settings"
+        android:icon="@drawable/ic_settings"
+        app:showAsAction="always" />
 </menu>

--- a/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
+++ b/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
@@ -23,7 +23,6 @@ import com.mapzen.erasermap.shadows.ShadowMapData
 import com.mapzen.erasermap.shadows.ShadowTangram
 import com.mapzen.pelias.SavedSearch
 import com.mapzen.pelias.gson.Feature
-import com.mapzen.pelias.widget.PeliasSearchView
 import com.mapzen.tangram.LngLat
 import com.mapzen.tangram.MapView
 import com.mapzen.valhalla.Route
@@ -87,8 +86,8 @@ public class MainActivityTest {
     public fun onCreateOptionsMenu_shouldInflateOptionsMenu() {
         val menu = RoboMenu()
         activity.onCreateOptionsMenu(menu)
-        assertThat(menu.findItem(R.id.action_search).getTitle()).isEqualTo("Search")
-        assertThat(menu.findItem(R.id.action_settings).getTitle()).isEqualTo("Settings")
+        assertThat(menu.findItem(R.id.action_view_all).title).isEqualTo("View All")
+        assertThat(menu.findItem(R.id.action_settings).title).isEqualTo("Settings")
     }
 
     @Test
@@ -118,9 +117,7 @@ public class MainActivityTest {
     public fun onDestroy_shouldSetCurrentSearchTerm() {
         val menu = RoboMenu()
         activity.onCreateOptionsMenu(menu)
-        menu.findItem(R.id.action_search).setActionView(PeliasSearchView(activity))
-        menu.findItem(R.id.action_search).expandActionView()
-        val searchView = menu.findItem(R.id.action_search).getActionView() as SearchView
+        val searchView = activity.supportActionBar.customView as SearchView
         searchView.setQuery("query", false)
         searchView.requestFocus()
         activity.onDestroy()
@@ -131,11 +128,9 @@ public class MainActivityTest {
     public fun onCreateOptionsMenu_shouldRestoreCurrentSearchTerm() {
         val menu = RoboMenu()
         activity.onCreateOptionsMenu(menu)
-        menu.findItem(R.id.action_search).setActionView(PeliasSearchView(activity))
-
         activity.presenter!!.currentSearchTerm = "query"
         activity.onCreateOptionsMenu(menu)
-        val searchView = menu.findItem(R.id.action_search).actionView as SearchView
+        val searchView = activity.supportActionBar.customView as SearchView
         assertThat(searchView.query).isEqualTo("query")
     }
 


### PR DESCRIPTION
* Removes search view menu item with action view auto-inflated by options menu.
* Adds `PeliasSearchView` to action bar as fully custom view with layout params.
* Updates custom search icon and clear icon.
* Search view now expands to full width of screen (minus action icons) in portrait and landscape mode.

Fixes #299 

![image](https://cloud.githubusercontent.com/assets/464123/12829380/b7d21c86-cb57-11e5-84ed-2ba7aa31a085.png)
