### PR TITLE
Update route icon positioning

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -11,7 +11,7 @@ public interface MainPresenter {
     companion object {
         val DEFAULT_ZOOM: Float = 16f
         val ROUTING_ZOOM: Float = 18f
-        val ROUTING_TILT: Float = 1.0472f // 60°
+        val ROUTING_TILT: Float = 0.83f // 47.5°
     }
 
     public var mainViewController: MainViewController?

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -247,7 +247,7 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
             val screenHeight = point.y.toDouble()
 
             // Find the view that will place the current location marker in the lower quarter of the window
-            val nextPosition = mapController?.coordinatesAtScreenPosition(screenWidth/2, screenHeight/3) ?: LngLat()
+            val nextPosition = mapController?.coordinatesAtScreenPosition(screenWidth/2, screenHeight/4) ?: LngLat()
             val nextRotation = getBearingInRadians(location)
 
             // Return to our initial view to prepare for easing to the next view


### PR DESCRIPTION
- sets the tilt angle to 47.5 (from 60).. since now we have perspective camera we do not need that much tilt
- update the position of the route icon at quater of the screen!

Fixes #323 


It looks like this now:

![screenshot_2016-02-05-12-13-56](https://cloud.githubusercontent.com/assets/360641/12853626/28e13f64-cc03-11e5-9e12-dbf9698a1ee8.png)

![screenshot_2016-02-05-12-14-05](https://cloud.githubusercontent.com/assets/360641/12853625/28def01a-cc03-11e5-9335-c99d8321a2a7.png)
