### PR TITLE
Route preview zooms to fit bounds of the route

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/util/AxisAlignedBoundingBox.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/util/AxisAlignedBoundingBox.kt
@@ -1,0 +1,65 @@
+package com.mapzen.erasermap.util
+
+/**
+ * An axis-aligned bounding box
+ *
+ * Useful class for finding the axis-aligned bounds of a set of 2D points
+ *
+ * @author Matt Blair
+ */
+
+public class AxisAlignedBoundingBox {
+
+    /**
+     * 2D point container like PointF, but with double precision
+     */
+    public class PointD(x: Double = 0.0, y: Double = 0.0) {
+        var x: Double = x
+        var y: Double = y
+    }
+
+    var min = PointD()
+    var max = PointD()
+
+    var center: PointD
+        get() {
+            return PointD(0.5 * (max.x + min.x), 0.5 * (max.y + min.y))
+        }
+        set(c: PointD) {
+            val hw = 0.5 * this.width
+            val hh = 0.5 * this.height
+            max = PointD(c.x + hw, c.y + hh)
+            min = PointD(c.x - hw, c.y - hh)
+        }
+
+    var width: Double
+        get() {
+            return max.x - min.x
+        }
+        set(w: Double) {
+            val c = this.center
+            max.x = c.x + 0.5 * w
+            min.x = c.x - 0.5 * w
+        }
+
+    var height: Double
+        get() {
+            return max.y - min.y
+        }
+        set(h: Double) {
+            val c = this.center
+            max.y = c.y + 0.5 * h
+            min.y = c.y - 0.5 * h
+        }
+
+    /**
+     * If (x, y) is outside the box, expands the box to reach it
+     */
+    public fun expandTo(x: Double, y: Double) {
+        max.x = Math.max(max.x, x)
+        max.y = Math.max(max.y, y)
+        min.x = Math.min(min.x, x)
+        min.y = Math.min(min.y, y)
+    }
+
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -687,10 +687,16 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         val zoomDelta = -Math.log(Math.max(scaleX, scaleY)) / Math.log(2.0)
 
         // Update map position and zoom
-        mapController?.mapPosition = LngLat(routeBounds.center.x, routeBounds.center.y)
-        val zoom = mapController?.mapZoom
-        if (zoom != null) {
-            mapController?.mapZoom = zoom + zoomDelta.toFloat()
+        var map = mapController
+        if (map != null) {
+            val z = map.mapZoom + zoomDelta.toFloat()
+            map.mapZoom = z
+            if (map.mapZoom == z) {
+                // If the new zoom would go beyond the bounds of the earth, the value
+                // won't be set - so we want to make sure that it changed before moving
+                // the position.
+                map.mapPosition = LngLat(routeBounds.center.x, routeBounds.center.y)
+            }
         }
 
         hideRoutePins()

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -642,7 +642,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
                 supportActionBar?.hide()
                 routePreviewView.visibility = View.VISIBLE
                 findViewById(R.id.route_preview_distance_time_view).visibility = View.VISIBLE
-                zoomToShowRoute(route)
+                zoomToShowRoute(route.getGeometry().toTypedArray())
             }
         })
         updateRoutePreview()
@@ -650,19 +650,23 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         hideProgress()
     }
 
-    private fun zoomToShowRoute(route: Route) {
+    private fun zoomToShowRoute(route: Array<Location>) {
+
+        // Make sure we have some points to work with
+        if (route.isEmpty()) {
+            return
+        }
 
         mapController?.mapRotation = 0f
         mapController?.mapTilt = 0f
 
         // Determine the smallest axis-aligned box that contains the route longitude and latitude
-        val geometry = route.getGeometry()
-        val start = geometry.first()
-        val finish = geometry.last()
+        val start = route.first()
+        val finish = route.last()
         var routeBounds = AxisAlignedBoundingBox()
         routeBounds.center = PointD(start.longitude, start.latitude)
 
-        for (p in geometry) {
+        for (p in route) {
             routeBounds.expandTo(p.longitude, p.latitude)
         }
 
@@ -717,6 +721,12 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
             val start = LngLat(origin.longitude, origin.latitude)
             val end = LngLat(destinationFeature.lng(), destinationFeature.lat())
             showRoutePins(start, end)
+
+            val startLocation = origin
+            val endLocation = Location(origin)
+            endLocation.longitude = end.longitude
+            endLocation.latitude = end.latitude
+            zoomToShowRoute(arrayOf(startLocation, endLocation))
         }
     }
 

--- a/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
+++ b/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
@@ -28,6 +28,7 @@ import com.mapzen.tangram.MapView
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.Router
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset.offset
 import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -202,11 +203,13 @@ public class MainActivityTest {
     }
 
     @Test
-    public fun showRoutePreview_shouldSetProperMapZoom() {
+    public fun showRoutePreview_shouldSetProperMapPositionAndZoom() {
         activity.showRoutePreview(getTestLocation(), getTestFeature())
         activity.success(TestRoute())
         Robolectric.flushForegroundThreadScheduler()
-        assertThat(activity.mapController!!.getMapZoom()).isEqualTo(0.5499235f)
+        assertThat(activity.mapController!!.getMapZoom()).isCloseTo(0.5f, offset(0.5f))
+        assertThat(activity.mapController!!.getMapPosition().longitude).isCloseTo(21.5, offset(0.5))
+        assertThat(activity.mapController!!.getMapPosition().latitude).isCloseTo(36.7, offset(0.5))
     }
 
     @Test


### PR DESCRIPTION
When previewing a route, this will calculate the lon/lat bounding box of the route geometry and move/zoom the map to show the entire route, taking into account the current screen dimensions, with a configurable amount of padding. If no route is found for a search, the preview will now zoom to fit the start and end pins. 

This also adds a utility class for an axis-aligned bounding box - might be useful in other places. 