### PR TITLE
Adds release build config

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,11 @@ def VALHALLA_API_KEY = hasProperty('valhallaApiKey') ? '"' + valhallaApiKey + '"
 def MINT_API_KEY = hasProperty('mintApiKey') ? '"' + mintApiKey + '"' : "null";
 def BUILD_NUMBER = hasProperty('buildNumber') ? '"' + buildNumber + '"' : '"DEV"';
 
+def RELEASE_STORE_FILE = hasProperty('releaseStoreFile') ? releaseStoreFile : "null";
+def RELEASE_STORE_PASSWORD = hasProperty('releaseStorePassword') ? releaseStorePassword : "null";
+def RELEASE_KEY_ALIAS = hasProperty('releaseKeyAlias') ? releaseKeyAlias : "null";
+def RELEASE_KEY_PASSWORD = hasProperty('releaseStoreFile') ? releaseKeyPassword : "null";
+
 android {
   compileSdkVersion 22
   buildToolsVersion "23.0.1"
@@ -29,37 +34,47 @@ android {
     targetSdkVersion 22
     versionCode 6
     versionName "0.4.1-SNAPSHOT"
+    buildConfigField "String", "VECTOR_TILE_API_KEY", VECTOR_TILE_API_KEY
+    buildConfigField "String", "PELIAS_API_KEY", PELIAS_API_KEY
+    buildConfigField "String", "VALHALLA_API_KEY", VALHALLA_API_KEY
+    buildConfigField "String", "MINT_API_KEY", MINT_API_KEY
+    buildConfigField "String", "BUILD_NUMBER", BUILD_NUMBER
   }
-  buildTypes {
-    debug {
-      buildConfigField "String", "VECTOR_TILE_API_KEY", VECTOR_TILE_API_KEY
-      buildConfigField "String", "PELIAS_API_KEY", PELIAS_API_KEY
-      buildConfigField "String", "VALHALLA_API_KEY", VALHALLA_API_KEY
-      buildConfigField "String", "MINT_API_KEY", MINT_API_KEY
-      buildConfigField "String", "BUILD_NUMBER", BUILD_NUMBER
-    }
-    release {
-      buildConfigField "String", "VECTOR_TILE_API_KEY", VECTOR_TILE_API_KEY
-      buildConfigField "String", "PELIAS_API_KEY", PELIAS_API_KEY
-      buildConfigField "String", "VALHALLA_API_KEY", VALHALLA_API_KEY
-      buildConfigField "String", "MINT_API_KEY", MINT_API_KEY
-      minifyEnabled false
-    }
-  }
-  sourceSets {
-    main.java.srcDirs += 'src/main/kotlin'
-    test.java.srcDirs += 'src/test/kotlin'
-  }
-  packagingOptions {
-    exclude 'META-INF/LICENSE.txt'
-  }
-  testOptions {
-    unitTests.returnDefaultValues = true
-  }
+
   signingConfigs {
     debug {
       storeFile file("debug.keystore")
     }
+
+    release {
+      storeFile file(RELEASE_STORE_FILE)
+      storePassword RELEASE_STORE_PASSWORD
+      keyAlias RELEASE_KEY_ALIAS
+      keyPassword RELEASE_KEY_PASSWORD
+    }
+  }
+
+  buildTypes {
+    debug {
+      signingConfig signingConfigs.debug
+    }
+    release {
+      signingConfig signingConfigs.release
+      minifyEnabled false
+    }
+  }
+
+  sourceSets {
+    main.java.srcDirs += 'src/main/kotlin'
+    test.java.srcDirs += 'src/test/kotlin'
+  }
+
+  packagingOptions {
+    exclude 'META-INF/LICENSE.txt'
+  }
+
+  testOptions {
+    unitTests.returnDefaultValues = true
   }
 }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
@@ -27,7 +27,11 @@ public class InitActivity : AppCompatActivity() {
         initCrashReportService()
         setContentView(R.layout.splash_screen)
         supportActionBar.hide()
-        (findViewById(R.id.build_number) as TextView).text = BuildConfig.BUILD_NUMBER
+
+        if (BuildConfig.DEBUG) {
+            (findViewById(R.id.build_number) as TextView).text = BuildConfig.BUILD_NUMBER
+        }
+
         Handler().postDelayed({ startMainActivity() }, START_DELAY_IN_MS)
     }
 


### PR DESCRIPTION
* Loads production keystore credentials via Gradle properties.
* Adds release signing config.
* Simplifies `BuildConfig` field creation for API keys and build number.
* Hides build number on splash screen in release builds.
* Adds some whitespace between closures to make `build.gradle` more readable.