### PR TITLE
339 dynamic zoom at transition

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -9,6 +9,7 @@ import com.mapzen.pelias.gson.Result
 
 public interface MainPresenter {
     companion object {
+        val LONG_MANEUVER_ZOOM: Float = 15f
         val DEFAULT_ZOOM: Float = 16f
         val ROUTING_ZOOM: Float = 18f
         val ROUTING_TILT: Float = 0.83f // 47.5°

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
@@ -28,4 +28,5 @@ public interface RoutePresenter {
     public fun onMuteClicked()
     public fun isMuted(): Boolean
     public fun setMuted(mute: Boolean)
+    public fun onCenterMapOnLocation(location: Location)
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -7,6 +7,7 @@ import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.helpers.RouteEngine
 import com.mapzen.valhalla.Instruction
 import com.mapzen.valhalla.Route
+import com.mapzen.valhalla.Router
 import com.squareup.otto.Bus
 
 public class RoutePresenterImpl(private val routeEngine: RouteEngine,
@@ -109,5 +110,20 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
 
     override fun setMuted(isMuted: Boolean) {
         muted = isMuted
+    }
+
+    override fun onCenterMapOnLocation(location: Location) {
+        var threshold: Int = 0
+        when (route?.units) {
+            Router.DistanceUnits.MILES -> threshold = (Instruction.MI_TO_METERS * 2).toInt()
+            Router.DistanceUnits.KILOMETERS -> threshold = Instruction.KM_TO_METERS * 3
+        }
+
+        val instruction = route?.getCurrentInstruction()
+        if (instruction != null && instruction.liveDistanceToNext > threshold) {
+            routeController?.updateMapZoom(MainPresenter.LONG_MANEUVER_ZOOM)
+        } else {
+            routeController?.updateMapZoom(MainPresenter.ROUTING_ZOOM)
+        }
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -266,7 +266,7 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
 
     override fun updateMapZoom(zoom: Float) {
         mapController?.queueEvent {
-            mapController?.mapZoom = zoom
+            mapController?.setMapZoom(zoom, 1f)
         }
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -230,16 +230,16 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
 
     override fun centerMapOnLocation(location: Location) {
         currentSnapLocation = location
+        routePresenter?.onCenterMapOnLocation(location)
         mapController?.queueEvent {
 
             // Record the initial view configuration
             val lastPosition = mapController?.mapPosition
             val lastRotation = mapController?.mapRotation
 
-            // Update position, rotation, tilt, and zoom for new location
+            // Update position, rotation, tilt for new location
             mapController?.mapPosition = LngLat(location.longitude, location.latitude)
             mapController?.mapRotation = getBearingInRadians(location)
-            mapController?.mapZoom = MainPresenter.ROUTING_ZOOM
             mapController?.mapTilt = MainPresenter.ROUTING_TILT
 
             // Get the width and height of the window
@@ -261,6 +261,12 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
             // Begin easing to the next view
             mapController?.setMapPosition(nextPosition.longitude, nextPosition.latitude, 1f, MapController.EaseType.LINEAR)
             mapController?.setMapRotation(nextRotation, 1f, MapController.EaseType.LINEAR)
+        }
+    }
+
+    override fun updateMapZoom(zoom: Float) {
+        mapController?.queueEvent {
+            mapController?.mapZoom = zoom
         }
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteViewController.kt
@@ -24,4 +24,5 @@ public interface RouteViewController {
     public fun hideRouteLine()
     public fun showRouteDirectionList()
     public fun hideRouteDirectionList()
+    public fun updateMapZoom(zoom: Float)
 }

--- a/app/src/test/java/fixtures/long_route.route
+++ b/app/src/test/java/fixtures/long_route.route
@@ -1,0 +1,75 @@
+{
+trip: {
+status: 0,
+status_message: "Found route between points",
+legs: [
+{
+shape: "g{yulA`q_clCpa@}qAjAwDrAeE~Nud@`BcFjAeE`g@}|Ase@c[se@e[ye@c[_i@bcBm_@flA",
+summary: {
+length: 0.879,
+time: 133
+},
+maneuvers: [
+{
+begin_shape_index: 0,
+length: 0.37,
+end_shape_index: 7,
+instruction: "Go southeast on West 26th Street.",
+street_names: [
+"West 26th Street"
+],
+type: 1,
+time: 0
+},
+{
+begin_shape_index: 7,
+length: 10000.237,
+end_shape_index: 10,
+instruction: "Turn left onto Madison Avenue.",
+street_names: [
+"Madison Avenue"
+],
+type: 15,
+time: 34
+},
+{
+begin_shape_index: 10,
+length: 10000.272,
+end_shape_index: 12,
+instruction: "Turn left onto East 29th Street.",
+street_names: [
+"East 29th Street"
+],
+type: 15,
+time: 46
+},
+{
+begin_shape_index: 12,
+length: 0,
+end_shape_index: 12,
+instruction: "You have arrived at your destination.",
+type: 4,
+time: 0
+}
+]
+}
+],
+units: "kilometers",
+summary: {
+length: 0.879,
+time: 133
+},
+locations: [
+{
+lon: -73.990433,
+lat: 40.744377,
+type: "break"
+},
+{
+lon: -73.988075,
+lat: 40.745811,
+type: "break"
+}
+]
+}
+}

--- a/app/src/test/java/fixtures/long_route.route
+++ b/app/src/test/java/fixtures/long_route.route
@@ -34,7 +34,7 @@ time: 34
 },
 {
 begin_shape_index: 10,
-length: 10000.272,
+length: 0.272,
 end_shape_index: 12,
 instruction: "Turn left onto East 29th Street.",
 street_names: [

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -7,13 +7,17 @@ import com.mapzen.erasermap.model.event.RouteCancelEvent
 import com.mapzen.erasermap.view.MapListToggleButton
 import com.mapzen.erasermap.view.TestRouteController
 import com.mapzen.helpers.RouteEngine
+import com.mapzen.valhalla.Instruction
 import com.mapzen.valhalla.Route
 import com.squareup.otto.Bus
 import com.squareup.otto.Subscribe
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
+@RunWith(RobolectricTestRunner::class)
 public class RoutePresenterTest {
     val routeEngine = RouteEngine()
     val routeListener = RouteEngineListener()
@@ -136,4 +140,19 @@ public class RoutePresenterTest {
             this.event = event
         }
     }
+
+    @Test fun onCenterMapOnLocation_shouldDynamicallySetZoom() {
+        val route = Route(getFixture("long_route"))
+        var location = route.getRouteInstructions()?.get(0)?.location
+        routeEngine.setListener(routeListener)
+        routeEngine.route = route
+        routePresenter.onRouteStart(route)
+        routePresenter.onCenterMapOnLocation(location as Location)
+        assertThat(routeController.mapZoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
+        location = route.getRouteInstructions()?.get(1)?.location
+        routeEngine.onLocationChanged(location)
+        routePresenter.onCenterMapOnLocation(location as Location)
+        assertThat(routeController.mapZoom).isEqualTo(MainPresenter.LONG_MANEUVER_ZOOM)
+    }
 }
+

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -154,5 +154,19 @@ public class RoutePresenterTest {
         routePresenter.onCenterMapOnLocation(location as Location)
         assertThat(routeController.mapZoom).isEqualTo(MainPresenter.LONG_MANEUVER_ZOOM)
     }
+
+    @Test fun onCenterMapOnLocation_shouldNotChangeZoomLevelForRelativelyShortManeuvers() {
+        val route = Route(getFixture("long_route"))
+        var location = route.getRouteInstructions()?.get(0)?.location
+        routeEngine.setListener(routeListener)
+        routeEngine.route = route
+        routePresenter.onRouteStart(route)
+        routePresenter.onCenterMapOnLocation(location as Location)
+        assertThat(routeController.mapZoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
+        location = route.getRouteInstructions()?.get(2)?.location
+        routeEngine.onLocationChanged(location)
+        routePresenter.onCenterMapOnLocation(location as Location)
+        assertThat(routeController.mapZoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
+    }
 }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
@@ -13,6 +13,7 @@ public class TestRouteController : RouteViewController {
     public var alert: Int = -1
     public var pre: Int = -1
     public var post: Int = -1
+    public var mapZoom: Float? = 0f
 
     override fun onLocationChanged(location: Location) {
         this.location = location
@@ -37,6 +38,7 @@ public class TestRouteController : RouteViewController {
     }
 
     override fun setCurrentInstruction(index: Int) {
+
     }
 
     override fun setMilestone(index: Int, milestone: RouteEngine.Milestone) {
@@ -83,5 +85,9 @@ public class TestRouteController : RouteViewController {
 
     override fun hideRouteDirectionList() {
         isDirectionListVisible = false
+    }
+
+    override fun updateMapZoom(zoom: Float) {
+        mapZoom = zoom
     }
 }


### PR DESCRIPTION
When a maneuver is long (over two miles/three kilometers) zoom the map out when in the middle of maneuver. Zoom back in towards end of maneuver.

Closes #339 