### PR TITLE
Hide setting action when in search mode

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -138,6 +138,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
     override fun onExpandSearchView() {
         vsm.viewState = ViewStateManager.ViewState.SEARCH
+        mainViewController?.hideSettingsBtn()
     }
 
     override fun onCollapseSearchView() {
@@ -147,7 +148,10 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
         mainViewController?.hideSearchResults()
         mainViewController?.hideActionViewAll()
-        mainViewController?.clearQuery()
+        if (vsm.viewState != ViewStateManager.ViewState.ROUTE_PREVIEW) {
+            mainViewController?.clearQuery()
+            mainViewController?.showSettingsBtn()
+        }
     }
 
     override fun onQuerySubmit() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -387,13 +387,14 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
             restoreCurrentSearchTerm(searchView)
             searchView.setOnPeliasFocusChangeListener { view, b ->
                 if (b) {
-                    presenter?.onExpandSearchView()
+                    expandSearchView()
                 } else if( presenter?.resultListVisible as Boolean) {
                         onCloseAllSearchResults()
                     } else {
                     searchView?.setQuery(presenter?.currentSearchTerm, false)
                 }
             }
+            searchView.setOnBackPressListener { collapseSearchView() }
         }
 
         return true
@@ -727,8 +728,20 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         presenter?.onCollapseSearchView()
     }
 
+    override fun expandSearchView() {
+        presenter?.onExpandSearchView()
+    }
+
     override fun clearQuery() {
         searchView?.setQuery("", false)
+    }
+
+    override fun hideSettingsBtn() {
+        optionsMenu?.findItem(R.id.action_settings)?.setVisible(false)
+    }
+
+    override fun showSettingsBtn() {
+        optionsMenu?.findItem(R.id.action_settings)?.setVisible(true)
     }
 
     override fun showRoutePreview(location: Location, feature: Feature) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainViewController.kt
@@ -21,6 +21,7 @@ public interface MainViewController {
     public fun showActionViewAll()
     public fun hideActionViewAll()
     public fun collapseSearchView()
+    public fun expandSearchView()
     public fun clearQuery()
     public fun showRoutePreview(location: Location, feature: Feature)
     public fun hideRoutePreview()
@@ -42,4 +43,6 @@ public interface MainViewController {
     public fun emptyPlaceSearch()
     public fun overridePlaceFeature(feature: Feature)
     public fun drawTappedPoiPin()
+    public fun hideSettingsBtn()
+    public fun showSettingsBtn()
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -174,6 +174,25 @@ public class MainPresenterTest {
         assertThat(mainController.queryText).isEmpty()
     }
 
+    @Test fun onCollapseSearchView_shouldShowActionSettings() {
+        mainController.isSettingsVisible = false
+        presenter.onCollapseSearchView()
+        assertThat(mainController.isSettingsVisible).isTrue()
+    }
+
+    @Test fun onCollapseSearchView_shouldNotShowActionSettingsIfViewStateSearchPreview() {
+        vsm.viewState = ViewStateManager.ViewState.ROUTE_PREVIEW
+        mainController.isSettingsVisible = false
+        presenter.onCollapseSearchView()
+        assertThat(mainController.isSettingsVisible).isFalse()
+    }
+
+    @Test fun onExpandSearchView_shouldHideActionSettings() {
+        mainController.isSettingsVisible = true
+        presenter.onExpandSearchView()
+        assertThat(mainController.isSettingsVisible).isFalse()
+    }
+
     @Test fun onRoutePreviewEvent_shouldCollapseSearchView() {
         mainController.isSearchVisible = true
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestMainController.kt
@@ -29,6 +29,7 @@ public class TestMainController : MainViewController {
     public var isCenteredOnTappedFeature: Boolean = false
     public var isReverseGeocodeVisible: Boolean = false
     public var isPlaceResultOverridden: Boolean = false
+    public var isSettingsVisible: Boolean = false
 
     override fun showSearchResults(features: List<Feature>) {
         searchResults = features
@@ -75,6 +76,9 @@ public class TestMainController : MainViewController {
 
     override fun collapseSearchView() {
         isSearchVisible = false
+    }
+
+    override fun expandSearchView() {
     }
 
     override fun clearQuery() {
@@ -171,5 +175,13 @@ public class TestMainController : MainViewController {
 
     override fun drawTappedPoiPin() {
         //empty
+    }
+
+    override fun hideSettingsBtn() {
+        isSettingsVisible = false
+    }
+
+    override fun showSettingsBtn() {
+        isSettingsVisible = true
     }
 }


### PR DESCRIPTION
- Hides setting icon when user is typing and when search results are displayed on map
- Updated text to not clear when search results are shown on map (wasn't able to confirm with Ekta that this is correct behavior so if we want to revert let me know)

Build fails because depends on: https://github.com/pelias/pelias-android-sdk/pull/33

Closes #391 