### PR TITLE
Change MainActivity's launchMode to singleTask

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".view.MainActivity"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:label="@string/app_name" />
         <activity
             android:name=".view.SearchResultsListActivity"


### PR DESCRIPTION
Our MainActivity's launch mode was preventing other activities that it opened from being added to it's task which made it seem like two instances of our app were running.

To reproduce, open settings and then go to the task switcher and see that there are two EraserMap cards in the task switcher.

I tested that notifications still open to the MainActivity when clicked- they do. I noticed that there are some bugs around notifications but the behavior is not due to this change. For example, when we completely kill the app and then click on the notification, it launches the MainActivity but you are not in routing mode. Also, when you cancel a route, the notification still exists until you click "exit navigation" inside the notification.

Let me know if there are other flows I should test aren't broken by this change.

Closes #300 