### PR TITLE
Parallel tests on Circle CI

### DIFF
--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -13,6 +13,7 @@ import com.mapzen.erasermap.model.ValhallaRouterFactory;
 import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
 import com.mapzen.erasermap.presenter.ViewStateManager;
+import com.mapzen.pelias.Pelias;
 
 import com.squareup.otto.Bus;
 
@@ -22,6 +23,7 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
+import retrofit.RestAdapter;
 
 @Module
 public class AndroidModule {
@@ -72,5 +74,11 @@ public class AndroidModule {
 
     @Provides @Singleton Bus provideBus() {
         return new Bus();
+    }
+
+    @Provides @Singleton Pelias providePelias() {
+        final RestAdapter.LogLevel logLevel = BuildConfig.DEBUG ?
+                RestAdapter.LogLevel.FULL : RestAdapter.LogLevel.NONE;
+        return Pelias.getPelias(logLevel);
     }
 }

--- a/app/src/main/java/com/mapzen/erasermap/CommonModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/CommonModule.java
@@ -6,7 +6,6 @@ import com.mapzen.erasermap.presenter.RoutePresenter;
 import com.mapzen.erasermap.presenter.RoutePresenterImpl;
 import com.mapzen.erasermap.presenter.ViewStateManager;
 import com.mapzen.helpers.RouteEngine;
-import com.mapzen.pelias.Pelias;
 import com.mapzen.pelias.SavedSearch;
 
 import com.squareup.otto.Bus;
@@ -15,7 +14,6 @@ import javax.inject.Singleton;
 
 import dagger.Module;
 import dagger.Provides;
-import retrofit.RestAdapter;
 
 @Module
 public class CommonModule {
@@ -42,11 +40,5 @@ public class CommonModule {
 
     @Provides @Singleton ApiKeys provideApiKeys() {
         return new ApiKeys("", "", "");
-    }
-
-    @Provides @Singleton Pelias providePelias() {
-        final RestAdapter.LogLevel logLevel = BuildConfig.DEBUG ?
-                RestAdapter.LogLevel.FULL : RestAdapter.LogLevel.NONE;
-        return Pelias.getPelias(logLevel);
     }
 }

--- a/app/src/main/java/com/mapzen/erasermap/model/SimpleCrypt.java
+++ b/app/src/main/java/com/mapzen/erasermap/model/SimpleCrypt.java
@@ -1,4 +1,4 @@
-package com.mapzen.erasermap;
+package com.mapzen.erasermap.model;
 
 import android.app.Application;
 import android.util.Base64;

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
@@ -10,8 +10,8 @@ import com.mapzen.erasermap.BuildConfig
 import com.mapzen.erasermap.CrashReportService
 import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
-import com.mapzen.erasermap.SimpleCrypt
 import com.mapzen.erasermap.model.ApiKeys
+import com.mapzen.erasermap.model.SimpleCrypt
 import javax.inject.Inject
 
 public class InitActivity : AppCompatActivity() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -373,7 +373,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
             pelias?.setApiKey(keys?.searchKey)
             searchView.setAutoCompleteListView(listView)
             searchView.setSavedSearch(savedSearch)
-            searchView.setPelias(Pelias.getPelias())
+            searchView.setPelias(pelias)
             searchView.setCallback(PeliasCallback())
             searchView.setOnSubmitListener({
                 saveCurrentSearchTerm()

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -1,7 +1,5 @@
 package com.mapzen.erasermap;
 
-import android.content.Context;
-
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.erasermap.model.AppSettings;
 import com.mapzen.erasermap.model.MapzenLocation;
@@ -13,9 +11,13 @@ import com.mapzen.erasermap.model.TileHttpHandler;
 import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
 import com.mapzen.erasermap.presenter.ViewStateManager;
+import com.mapzen.pelias.Pelias;
+
 import com.squareup.otto.Bus;
 
 import org.mockito.Mockito;
+
+import android.content.Context;
 
 import javax.inject.Singleton;
 
@@ -68,5 +70,9 @@ public class TestAndroidModule {
 
     @Provides @Singleton Bus provideBus() {
         return new Bus();
+    }
+
+    @Provides @Singleton Pelias providePelias() {
+        return Mockito.mock(Pelias.class);
     }
 }

--- a/app/src/test/java/com/mapzen/erasermap/model/SimpleCryptTest.java
+++ b/app/src/test/java/com/mapzen/erasermap/model/SimpleCryptTest.java
@@ -1,4 +1,7 @@
-package com.mapzen.erasermap;
+package com.mapzen.erasermap.model;
+
+import com.mapzen.erasermap.BuildConfig;
+import com.mapzen.erasermap.PrivateMapsTestRunner;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/app/src/test/java/com/mapzen/erasermap/shadows/ShadowMapController.java
+++ b/app/src/test/java/com/mapzen/erasermap/shadows/ShadowMapController.java
@@ -3,6 +3,7 @@ package com.mapzen.erasermap.shadows;
 import com.mapzen.tangram.LngLat;
 import com.mapzen.tangram.MapController;
 import com.mapzen.tangram.MapView;
+import com.mapzen.tangram.TouchInput;
 
 import org.robolectric.annotation.Implementation;
 import org.robolectric.annotation.Implements;
@@ -21,6 +22,9 @@ public class ShadowMapController {
     private ArrayList<Runnable> eventQueue = new ArrayList<>();
 
     public void __constructor__(Activity mainApp, MapView view) {
+    }
+
+    public void __constructor__(Activity mainApp, MapView view, String sceneFilePath) {
     }
 
     @Implementation
@@ -66,5 +70,35 @@ public class ShadowMapController {
 
     public List<Runnable> getEventQueue() {
         return eventQueue;
+    }
+
+    @Implementation
+    public void setLongPressResponder(final TouchInput.LongPressResponder responder) {
+        // Do nothing
+    }
+
+    @Implementation
+    public void setTapResponder(final TouchInput.TapResponder responder) {
+        // Do nothing
+    }
+
+    @Implementation
+    public void setDoubleTapResponder(final TouchInput.DoubleTapResponder responder) {
+        // Do nothing
+    }
+
+    @Implementation
+    public void setRotateResponder(final TouchInput.RotateResponder responder) {
+        // Do nothing
+    }
+
+    @Implementation
+    public void setPanResponder(final TouchInput.PanResponder responder) {
+        // Do nothing
+    }
+
+    @Implementation
+    public void requestRender() {
+        // Do nothing
     }
 }

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,8 @@ machine:
     version: jruby-1.7.12
   environment:
     ANDROID_HOME: /usr/local/android-sdk-linux
-    JAVA_OPTS: "-Xmx512m -XX:MaxPermSize=512m"
+    JAVA_OPTS: "-Xmx256m -XX:MaxPermSize=256m"
+    TEST_OPTS: "-PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY -PpeliasApiKey=$PELIAS_API_KEY -PvalhallaApiKey=$VALHALLA_API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM"
 
 dependencies:
   pre:
@@ -13,8 +14,14 @@ dependencies:
     - git submodule init; git submodule update
 
 test:
+  pre:
+    - ./gradlew assembleDevDebug $TEST_OPTS
   override:
-    - ./gradlew --refresh-dependencies -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY -PpeliasApiKey=$PELIAS_API_KEY -PvalhallaApiKey=$VALHALLA_API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
+    - case $CIRCLE_NODE_INDEX in 0) ./gradlew testDevDebug --tests='*.model.*' $TEST_OPTS ;; 1) ./gradlew testDevDebug --tests='*.view.*' $TEST_OPTS ;; 2) ./gradlew testDevDebug --tests='*.presenter.*' $TEST_OPTS ;; esac:
+        parallel: true
+  post:
+    - mkdir -p $CIRCLE_TEST_REPORTS/junit
+    - cp app/build/test-results/devDebug/*.xml $CIRCLE_TEST_REPORTS/junit
 
 deployment:
   all:

--- a/scripts/encrypter.rb
+++ b/scripts/encrypter.rb
@@ -2,5 +2,5 @@ require "android-all-4.4_r1-robolectric-0.jar"
 $CLASSPATH << 'app/src/main/java'
 special_salt = ARGV[0]
 to_encode = ARGV[1]
-simple_crypt = com.mapzen.erasermap.SimpleCrypt.withSpecialSalt(special_salt)
+simple_crypt = com.mapzen.erasermap.model.SimpleCrypt.withSpecialSalt(special_salt)
 puts simple_crypt.encode(to_encode)


### PR DESCRIPTION
Runs tests by package in parallel split across 3 nodes (model, view, presenter). Reduces Gradle memory allocation for each node. Uses Circle CI  environment variable test run options.

Also removes `--refresh-dependencies` option to speed up compile time. If you update a library SNAPSHOT version and your build fails due to compile error on Circle CI then try rerunning using "Rebuild without cache" option.

Additional measures to reduce memory consumption include mocking the `Pelias` instance and shadowing additional `MapController` methods to prevent spawn of unwanted background threads during tests.