### PR TITLE
Set mapZoom in same event as mapPostition when centering on location

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
@@ -28,5 +28,5 @@ public interface RoutePresenter {
     public fun onMuteClicked()
     public fun isMuted(): Boolean
     public fun setMuted(mute: Boolean)
-    public fun onCenterMapOnLocation(location: Location)
+    public fun mapZoomLevelForCenterMapOnLocation(location: Location): Float
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -118,7 +118,7 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
      * completing it. If the maneuver is relatively short we won't adjust the zoom level which will
      * prevent changing the zoom too frequently
      */
-    override fun onCenterMapOnLocation(location: Location) {
+    override fun mapZoomLevelForCenterMapOnLocation(location: Location): Float  {
         var liveDistanceThreshold: Int = 0
         var distanceThreshold: Int = 0
                 when (route?.units) {
@@ -135,9 +135,9 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
         val instruction = route?.getCurrentInstruction()
         if (instruction != null && instruction.liveDistanceToNext > liveDistanceThreshold
                 && instruction.distance > distanceThreshold) {
-            routeController?.updateMapZoom(MainPresenter.LONG_MANEUVER_ZOOM)
+            return MainPresenter.LONG_MANEUVER_ZOOM
         } else {
-            routeController?.updateMapZoom(MainPresenter.ROUTING_ZOOM)
+            return MainPresenter.ROUTING_ZOOM
         }
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -231,7 +231,6 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
 
     override fun centerMapOnLocation(location: Location) {
         currentSnapLocation = location
-        routePresenter?.onCenterMapOnLocation(location)
         mapController?.queueEvent {
 
             // Record the initial view configuration
@@ -242,6 +241,7 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
             mapController?.mapPosition = LngLat(location.longitude, location.latitude)
             mapController?.mapRotation = getBearingInRadians(location)
             mapController?.mapTilt = MainPresenter.ROUTING_TILT
+            mapController?.mapZoom = routePresenter?.mapZoomLevelForCenterMapOnLocation(location)
 
             // Get the width and height of the window
             val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -147,12 +147,12 @@ public class RoutePresenterTest {
         routeEngine.setListener(routeListener)
         routeEngine.route = route
         routePresenter.onRouteStart(route)
-        routePresenter.onCenterMapOnLocation(location as Location)
-        assertThat(routeController.mapZoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
+        var routingZoom = routePresenter.mapZoomLevelForCenterMapOnLocation(location as Location)
+        assertThat(routingZoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
         location = route.getRouteInstructions()?.get(1)?.location
         routeEngine.onLocationChanged(location)
-        routePresenter.onCenterMapOnLocation(location as Location)
-        assertThat(routeController.mapZoom).isEqualTo(MainPresenter.LONG_MANEUVER_ZOOM)
+        var longManeuverZoom = routePresenter.mapZoomLevelForCenterMapOnLocation(location as Location)
+        assertThat(longManeuverZoom).isEqualTo(MainPresenter.LONG_MANEUVER_ZOOM)
     }
 
     @Test fun onCenterMapOnLocation_shouldNotChangeZoomLevelForRelativelyShortManeuvers() {
@@ -161,12 +161,12 @@ public class RoutePresenterTest {
         routeEngine.setListener(routeListener)
         routeEngine.route = route
         routePresenter.onRouteStart(route)
-        routePresenter.onCenterMapOnLocation(location as Location)
-        assertThat(routeController.mapZoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
+        var routingZoom = routePresenter.mapZoomLevelForCenterMapOnLocation(location as Location)
+        assertThat(routingZoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
         location = route.getRouteInstructions()?.get(2)?.location
         routeEngine.onLocationChanged(location)
-        routePresenter.onCenterMapOnLocation(location as Location)
-        assertThat(routeController.mapZoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
+        routingZoom = routePresenter.mapZoomLevelForCenterMapOnLocation(location as Location)
+        assertThat(routingZoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
     }
 }
 


### PR DESCRIPTION
When these aren't set in the same event, it causes the camera to not be set in the correct position