### PR TITLE
Disable route preview buttons instead of hiding when no route

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/MainActivity.kt
@@ -15,6 +15,7 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.Button
 import android.widget.ImageButton
+import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.RelativeLayout
 import android.widget.TextView
@@ -122,6 +123,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     val muteView: MuteView by lazy { findViewById(R.id.route_mode_mute_view) as MuteView }
     val searchResultsView: SearchResultsView by lazy { findViewById(R.id.search_results) as SearchResultsView }
     val osmAttributionText: TextView by lazy { findViewById(R.id.osm_attribution) as TextView }
+    val routePreviewDistanceTimeLayout: LinearLayout by lazy { findViewById(R.id.route_preview_distance_time_view) as LinearLayout }
 
     override public fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -773,7 +775,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
             if (routeModeView.visibility != View.VISIBLE) {
                 supportActionBar?.hide()
                 routePreviewView.visibility = View.VISIBLE
-                findViewById(R.id.route_preview_distance_time_view).visibility = View.VISIBLE
+                routePreviewDistanceTimeLayout.visibility = View.VISIBLE
                 zoomToShowRoute(route.getGeometry().toTypedArray())
             }
         })
@@ -875,7 +877,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
             if (routeModeView.visibility != View.VISIBLE) {
                 supportActionBar?.hide()
                 routePreviewView.visibility = View.VISIBLE
-                findViewById(R.id.route_preview_distance_time_view).visibility = View.GONE
+                routePreviewDistanceTimeLayout.visibility = View.INVISIBLE
                 handleRouteFailure()
             }
         })
@@ -1099,4 +1101,5 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         startPin = null
         endPin = null
     }
+
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
@@ -78,12 +78,13 @@ public class RoutePreviewView : RelativeLayout {
     }
 
     public fun disableStartNavigation() {
-        startNavigationButton?.visibility = GONE
-        viewListButton?.visibility = GONE
+        startNavigationButton?.isEnabled = false
+        viewListButton?.isEnabled = false
     }
 
     public fun enableStartNavigation() {
-        startNavigationButton?.visibility = VISIBLE
-        viewListButton?.visibility = VISIBLE
+        startNavigationButton?.isEnabled = true
+        viewListButton?.isEnabled = true
     }
+
 }

--- a/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
+++ b/app/src/test/java/com/mapzen/erasermap/view/MainActivityTest.kt
@@ -236,12 +236,21 @@ public class MainActivityTest {
     }
 
     @Test
-    public fun showRoutePreviewFailure_shouldHideStartNavigation() {
+    public fun showRoutePreviewFailure_shouldDisableStartNavigation() {
         activity.showRoutePreview(getTestLocation(), getTestFeature())
         activity.failure(0)
         Robolectric.flushForegroundThreadScheduler()
-        assertThat(activity.findViewById(R.id.start_navigation).visibility).isEqualTo(View.GONE)
-        assertThat(activity.findViewById(R.id.view_list).visibility).isEqualTo(View.GONE)
+        assertThat(activity.findViewById(R.id.start_navigation).isEnabled).isEqualTo(false)
+        assertThat(activity.findViewById(R.id.view_list).isEnabled).isEqualTo(false)
+    }
+
+    @Test
+    public fun showRoutePreviewFailure_shouldHideTimeDistance() {
+        activity.showRoutePreview(getTestLocation(), getTestFeature())
+        activity.failure(0)
+        Robolectric.flushForegroundThreadScheduler()
+        assertThat(activity.routePreviewDistanceTimeLayout.getVisibility()).isEqualTo(
+                View.INVISIBLE)
     }
 
     @Test


### PR DESCRIPTION
Also set the time/distance layout to be invisible instead of gone so that spacing is preserved when no route

Closes #425 