### PR TITLE
438 clear mapdata

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -109,6 +109,8 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     var autoCompleteAdapter: AutoCompleteAdapter? = null
     var optionsMenu: Menu? = null
     var findMe: MapData? = null
+    var reverseGeocodeData: MapData? = null
+    var searchResultsData: MapData? = null
     var startPin: MapData? = null
     var endPin: MapData? = null
     var poiTapPoint: FloatArray? = null
@@ -214,6 +216,8 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         saveCurrentSearchTerm()
         routeModeView.clearRoute()
         findMe?.clear()
+        reverseGeocodeData?.clear()
+        searchResultsData?.clear()
         killNotifications()
     }
 
@@ -601,12 +605,12 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
 
         val properties = com.mapzen.tangram.Properties()
         properties.set(MAP_DATA_PROP_STATE, MAP_DATA_PROP_STATE_ACTIVE)
-        if (presenter?.reverseGeocodeData == null) {
-            presenter?.reverseGeocodeData = MapData("reverse_geocode")
-            Tangram.addDataSource(presenter?.reverseGeocodeData)
+        if (reverseGeocodeData == null) {
+            reverseGeocodeData = MapData("reverse_geocode")
+            Tangram.addDataSource(reverseGeocodeData)
         }
-        presenter?.reverseGeocodeData?.clear()
-        presenter?.reverseGeocodeData?.addPoint(properties, lngLat)
+        reverseGeocodeData?.clear()
+        reverseGeocodeData?.addPoint(properties, lngLat)
 
         mapController?.requestRender()
     }
@@ -627,12 +631,12 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         properties.set(MAP_DATA_PROP_STATE, MAP_DATA_PROP_STATE_ACTIVE)
 
         // hijack reverseGeocodeData for tappedPoiPin
-        if (presenter?.reverseGeocodeData == null) {
-            presenter?.reverseGeocodeData = MapData("reverse_geocode")
-            Tangram.addDataSource(presenter?.reverseGeocodeData)
+        if (reverseGeocodeData == null) {
+            reverseGeocodeData = MapData("reverse_geocode")
+            Tangram.addDataSource(reverseGeocodeData)
         }
-        presenter?.reverseGeocodeData?.clear()
-        presenter?.reverseGeocodeData?.addPoint(properties, lngLat)
+        reverseGeocodeData?.clear()
+        reverseGeocodeData?.addPoint(properties, lngLat)
 
         mapController?.requestRender()
     }
@@ -646,13 +650,13 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     override fun addSearchResultsToMap(features: List<Feature>, activeIndex: Int) {
         centerOnCurrentFeature(features)
 
-        if (presenter?.searchResultsData == null) {
-            presenter?.searchResultsData = MapData("search")
-            Tangram.addDataSource(presenter?.searchResultsData)
+        if (searchResultsData == null) {
+            searchResultsData = MapData("search")
+            Tangram.addDataSource(searchResultsData)
         }
 
         var featureCount: Int = 0
-        presenter?.searchResultsData?.clear()
+        searchResultsData?.clear()
         for (feature in features) {
             val simpleFeature = SimpleFeature.fromFeature(feature)
             val lngLat = LngLat(simpleFeature.lng(), simpleFeature.lat())
@@ -663,7 +667,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
             } else {
                 properties.set(MAP_DATA_PROP_STATE, MAP_DATA_PROP_STATE_INACTIVE);
             }
-            presenter?.searchResultsData?.addPoint(properties, lngLat)
+            searchResultsData?.addPoint(properties, lngLat)
             featureCount++
         }
         mapController?.requestRender()
@@ -705,13 +709,13 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     }
 
     override fun hideReverseGeolocateResult() {
-        presenter?.reverseGeocodeData?.clear()
+        reverseGeocodeData?.clear()
     }
 
     override fun hideSearchResults() {
         hideSearchResultsView()
         layoutAttributionAlignBottom()
-        presenter?.searchResultsData?.clear()
+        searchResultsData?.clear()
     }
 
     private fun hideSearchResultsView() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -586,7 +586,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
 
     override fun showReverseGeocodeFeature(features: List<Feature>) {
         hideSearchResults()
-        centerOnCurrentFeature(features)
         layoutAttributionAboveSearchResults(features)
 
         var poiTapFallback = false

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -110,7 +110,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     var optionsMenu: Menu? = null
     var findMe: MapData? = null
     var searchResults: MapData? = null
-    var reverseGeocodeData: MapData? = null
     var startPin: MapData? = null
     var endPin: MapData? = null
     var poiTapPoint: FloatArray? = null
@@ -217,6 +216,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         routeModeView.clearRoute()
         findMe?.clear()
         killNotifications()
+        Tangram.clearDataSource(presenter?.reverseGeocodeData, true, true)
     }
 
     private fun initMapController() {
@@ -269,6 +269,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
                 }
         })
         mapController?.setHttpHandler(tileHttpHandler)
+
         mapzenLocation?.mapController = mapController
     }
 
@@ -603,12 +604,12 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
 
         val properties = com.mapzen.tangram.Properties()
         properties.set(MAP_DATA_PROP_STATE, MAP_DATA_PROP_STATE_ACTIVE)
-        if (reverseGeocodeData == null) {
-            reverseGeocodeData = MapData("reverse_geocode")
-            Tangram.addDataSource(reverseGeocodeData)
+        if (presenter?.reverseGeocodeData == null) {
+            presenter?.reverseGeocodeData = MapData("reverse_geocode")
+            Tangram.addDataSource(presenter?.reverseGeocodeData)
         }
-        reverseGeocodeData?.clear()
-        reverseGeocodeData?.addPoint(properties, lngLat)
+        presenter?.reverseGeocodeData?.clear()
+        presenter?.reverseGeocodeData?.addPoint(properties, lngLat)
 
         mapController?.requestRender()
     }
@@ -629,12 +630,12 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         properties.set(MAP_DATA_PROP_STATE, MAP_DATA_PROP_STATE_ACTIVE)
 
         // hijack reverseGeocodeData for tappedPoiPin
-        if (reverseGeocodeData == null) {
-            reverseGeocodeData = MapData("reverse_geocode")
-            Tangram.addDataSource(reverseGeocodeData)
+        if (presenter?.reverseGeocodeData == null) {
+            presenter?.reverseGeocodeData = MapData("reverse_geocode")
+            Tangram.addDataSource(presenter?.reverseGeocodeData)
         }
-        reverseGeocodeData?.clear()
-        reverseGeocodeData?.addPoint(properties, lngLat)
+        presenter?.reverseGeocodeData?.clear()
+        presenter?.reverseGeocodeData?.addPoint(properties, lngLat)
 
         mapController?.requestRender()
     }
@@ -707,7 +708,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     }
 
     override fun hideReverseGeolocateResult() {
-        reverseGeocodeData?.clear()
+        presenter?.reverseGeocodeData?.clear()
     }
 
     override fun hideSearchResults() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -6,6 +6,7 @@ import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.pelias.PeliasLocationProvider
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.gson.Result
+import com.mapzen.tangram.MapData
 
 public interface MainPresenter {
     companion object {
@@ -21,6 +22,7 @@ public interface MainPresenter {
     public var currentFeature: Feature?
     public var routingEnabled: Boolean
     public var resultListVisible: Boolean
+    public var reverseGeocodeData: MapData?
 
     public fun onSearchResultsAvailable(result: Result?)
     public fun onReverseGeocodeResultsAvailable(searchResults: Result?)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -6,7 +6,6 @@ import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.pelias.PeliasLocationProvider
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.gson.Result
-import com.mapzen.tangram.MapData
 
 public interface MainPresenter {
     companion object {
@@ -22,8 +21,6 @@ public interface MainPresenter {
     public var currentFeature: Feature?
     public var routingEnabled: Boolean
     public var resultListVisible: Boolean
-    public var reverseGeocodeData: MapData?
-    public var searchResultsData: MapData?
     public var reverseGeo: Boolean
 
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -23,6 +23,9 @@ public interface MainPresenter {
     public var routingEnabled: Boolean
     public var resultListVisible: Boolean
     public var reverseGeocodeData: MapData?
+    public var searchResultsData: MapData?
+    public var reverseGeo: Boolean
+
 
     public fun onSearchResultsAvailable(result: Result?)
     public fun onReverseGeocodeResultsAvailable(searchResults: Result?)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -123,6 +123,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
                 mainViewController?.showSearchResults(searchResults?.features)
             } else {
                 mainViewController?.showReverseGeocodeFeature(searchResults?.features)
+                mainViewController?.centerOnCurrentFeature(searchResults?.features)
             }
         }
     }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -20,7 +20,6 @@ import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.pelias.PeliasLocationProvider
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.gson.Result
-import com.mapzen.tangram.MapData
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import com.squareup.otto.Bus
@@ -37,8 +36,6 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     override var routeViewController: RouteViewController? = null
     override var currentSearchTerm: String? = null
     override var resultListVisible = false
-    override var reverseGeocodeData: MapData? = null
-    override var searchResultsData: MapData? = null
     override var reverseGeo = false
 
     private var searchResults: Result? = null
@@ -64,7 +61,6 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     }
 
     override fun onReverseGeocodeResultsAvailable(searchResults: Result?) {
-        reverseGeo = true
         vsm.viewState = ViewStateManager.ViewState.SEARCH_RESULTS
         var features = ArrayList<Feature>()
         this.searchResults = searchResults

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -38,11 +38,12 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     override var currentSearchTerm: String? = null
     override var resultListVisible = false
     override var reverseGeocodeData: MapData? = null
+    override var searchResultsData: MapData? = null
+    override var reverseGeo = false
 
     private var searchResults: Result? = null
     private var destination: Feature? = null
     private var initialized = false
-    private var reverseGeo = false
 
     init {
         bus.register(this)
@@ -63,6 +64,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     }
 
     override fun onReverseGeocodeResultsAvailable(searchResults: Result?) {
+        reverseGeo = true
         vsm.viewState = ViewStateManager.ViewState.SEARCH_RESULTS
         var features = ArrayList<Feature>()
         this.searchResults = searchResults
@@ -121,7 +123,11 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
     private fun onRestoreViewStateSearchResults() {
         if (searchResults?.features != null) {
-            mainViewController?.showSearchResults(searchResults?.features)
+            if (!reverseGeo) {
+                mainViewController?.showSearchResults(searchResults?.features)
+            } else {
+                mainViewController?.showReverseGeocodeFeature(searchResults?.features)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -20,6 +20,7 @@ import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.pelias.PeliasLocationProvider
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.gson.Result
+import com.mapzen.tangram.MapData
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import com.squareup.otto.Bus
@@ -36,6 +37,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     override var routeViewController: RouteViewController? = null
     override var currentSearchTerm: String? = null
     override var resultListVisible = false
+    override var reverseGeocodeData: MapData? = null
 
     private var searchResults: Result? = null
     private var destination: Feature? = null

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/MainActivityTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/MainActivityTest.kt
@@ -276,7 +276,7 @@ public class MainActivityTest {
         features.add(getTestFeature())
         features.add(getTestFeature())
         activity.showSearchResults(features)
-        val shadowSearchResults = ShadowExtractor.extract(activity.presenter?.searchResultsData) as ShadowMapData
+        val shadowSearchResults = ShadowExtractor.extract(activity.searchResultsData) as ShadowMapData
         assertThat(shadowSearchResults.points).hasSize(3)
     }
 
@@ -288,7 +288,7 @@ public class MainActivityTest {
         features.add(getTestFeature())
         activity.showSearchResults(features)
         activity.showSearchResults(features)
-        val shadowSearchResults = ShadowExtractor.extract(activity.presenter?.searchResultsData) as ShadowMapData
+        val shadowSearchResults = ShadowExtractor.extract(activity.searchResultsData) as ShadowMapData
         assertThat(shadowSearchResults.points).hasSize(3)
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/MainActivityTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/MainActivityTest.kt
@@ -276,7 +276,7 @@ public class MainActivityTest {
         features.add(getTestFeature())
         features.add(getTestFeature())
         activity.showSearchResults(features)
-        val shadowSearchResults = ShadowExtractor.extract(activity.searchResults) as ShadowMapData
+        val shadowSearchResults = ShadowExtractor.extract(activity.presenter?.searchResultsData) as ShadowMapData
         assertThat(shadowSearchResults.points).hasSize(3)
     }
 
@@ -288,7 +288,7 @@ public class MainActivityTest {
         features.add(getTestFeature())
         activity.showSearchResults(features)
         activity.showSearchResults(features)
-        val shadowSearchResults = ShadowExtractor.extract(activity.searchResults) as ShadowMapData
+        val shadowSearchResults = ShadowExtractor.extract(activity.presenter?.searchResultsData) as ShadowMapData
         assertThat(shadowSearchResults.points).hasSize(3)
     }
 


### PR DESCRIPTION
- Moves searchResults & reverseGeocodeData MapData to MainPresenter so that objects persist on rotation changes
- Exposes MainPresenter's reverseGeo var so that it can be used to properly restore state on rotation changes
- Properly handles rotation changes when reverse geocoded results are shown (centers on map, updates options menu, etc)

Closes #438 