### PR TITLE
Speakerbox Rotation Fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,7 +138,7 @@ dependencies {
   }
   compile 'com.splunk.mint:mint:4.2.1'
   compile 'com.squareup.okhttp:okhttp:2.4.0'
-  compile 'com.mapzen.android:speakerbox:1.2.0'
+  compile 'com.mapzen.android:speakerbox:1.3.0'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.9.5'

--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -14,6 +14,7 @@ import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
 import com.mapzen.erasermap.presenter.ViewStateManager;
 import com.mapzen.pelias.Pelias;
+import com.mapzen.speakerbox.Speakerbox;
 
 import com.squareup.otto.Bus;
 
@@ -80,5 +81,9 @@ public class AndroidModule {
         final RestAdapter.LogLevel logLevel = BuildConfig.DEBUG ?
                 RestAdapter.LogLevel.FULL : RestAdapter.LogLevel.NONE;
         return Pelias.getPelias(logLevel);
+    }
+
+    @Provides @Singleton Speakerbox provideSpeakerbox() {
+        return new Speakerbox(application);
     }
 }

--- a/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
+++ b/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
@@ -6,6 +6,7 @@ import com.mapzen.erasermap.view.InitActivity;
 import com.mapzen.erasermap.view.RouteModeView;
 import com.mapzen.erasermap.view.SearchResultsAdapter;
 import com.mapzen.erasermap.view.SettingsActivity;
+import com.mapzen.erasermap.view.VoiceNavigationController;
 
 import android.app.Application;
 
@@ -23,6 +24,7 @@ public class EraserMapApplication extends Application {
         void inject(RouteModeView routeModeView);
         void inject(SettingsActivity settingsFragment);
         void inject(DistanceView distanceView);
+        void inject(VoiceNavigationController controller);
     }
 
     private ApplicationComponent component;

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -104,7 +104,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     var pelias: Pelias? = null
         @Inject set
 
-    var app: EraserMapApplication? = null
+    lateinit var app: EraserMapApplication
     var mapController : MapController? = null
     var autoCompleteAdapter: AutoCompleteAdapter? = null
     var optionsMenu: Menu? = null
@@ -140,12 +140,13 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     override public fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         app = application as EraserMapApplication
-        app?.component()?.inject(this)
+        app.component().inject(this)
         initCrashReportService()
         setContentView(R.layout.activity_main)
         presenter?.mainViewController = this
         initMapController()
         initFindMeButton()
+        initVoiceNavigationController() // must initialize this before calling initMute
         initMute()
         initCompass()
         initReverseButton()
@@ -154,7 +155,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         presenter?.onRestoreViewState()
         supportActionBar?.setDisplayShowTitleEnabled(false)
         settings?.initTangramDebugFlags()
-        initVoiceNavigationController()
         initNotificationCreator()
     }
 
@@ -285,8 +285,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     }
 
     private fun updateMute() {
-        val routePresenter = routeModeView.routePresenter
-        muteView.setMuted(routePresenter?.isMuted() != true)
+        muteView.setMuted(voiceNavigationController?.isMuted() != true)
     }
 
     private fun initMute() {
@@ -314,10 +313,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
 
     private fun initVoiceNavigationController() {
         voiceNavigationController = VoiceNavigationController(this)
-        val routePresenter = routeModeView.routePresenter
-        if (routePresenter?.isMuted() == true) {
-            voiceNavigationController?.mute()
-        }
     }
 
     private fun initNotificationCreator() {
@@ -344,18 +339,13 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     }
 
     override fun toggleMute() {
-        //Update cached value of routePresenter.isMuted
-        val routePresenter = routeModeView.routePresenter
-        routePresenter?.onMuteClicked()
-
-        val muted = (routePresenter?.isMuted() == true)
-        muteView.setMuted(!muted)
-
-        //Actually mute or unmute the speakerbox based on current value
+        val muted = (voiceNavigationController?.isMuted() == true)
         if (muted) {
-            routeModeView.voiceNavigationController?.mute()
+            muteView.setMuted(true)
+            voiceNavigationController?.unmute()
         } else {
-            routeModeView.voiceNavigationController?.unmute()
+            muteView.setMuted(false)
+            voiceNavigationController?.mute()
         }
     }
 
@@ -1006,8 +996,8 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     }
 
     override fun resetMute() {
-        val routePresenter = routeModeView.routePresenter
-        routePresenter?.setMuted(false)
+        voiceNavigationController?.unmute()
+        muteView.setMuted(true)
     }
 
     override fun resumeRoutingMode(feature: Feature) {
@@ -1080,6 +1070,10 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         }
         poiTapName = null
         poiTapPoint = null
+    }
+
+    override fun stopSpeaker() {
+        voiceNavigationController?.stop()
     }
 
     private fun exitNavigation() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -286,7 +286,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
 
     private fun updateMute() {
         val routePresenter = routeModeView.routePresenter
-        muteView.setMuted(!(routePresenter?.isMuted() == true))
+        muteView.setMuted(routePresenter?.isMuted() != true)
     }
 
     private fun initMute() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -45,4 +45,5 @@ public interface MainViewController {
     public fun hideSettingsBtn()
     public fun showSettingsBtn()
     public fun onBackPressed()
+    public fun stopSpeaker()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -250,6 +250,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     private fun onBackPressedStateRouting() {
         vsm.viewState = ViewStateManager.ViewState.ROUTE_PREVIEW
         mainViewController?.hideRoutingMode()
+        mainViewController?.stopSpeaker()
     }
 
     private fun onBackPressedStateRouteDirectionList() {
@@ -263,10 +264,10 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
 
     override fun onClickStartNavigation() {
         bus.post(RouteEvent())
+        mainViewController?.resetMute() //must call before generateRoutingMode()
         generateRoutingMode()
         vsm.viewState = ViewStateManager.ViewState.ROUTING
         routeViewController?.hideResumeButton()
-        mainViewController?.resetMute()
     }
 
     @Subscribe public fun onLocationChangeEvent(event: LocationChangeEvent) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
@@ -25,8 +25,5 @@ public interface RoutePresenter {
     public fun onRouteClear()
     public fun onMapListToggleClick(state: MapListToggleButton.MapListState)
     public fun onRouteCancelButtonClick()
-    public fun onMuteClicked()
-    public fun isMuted(): Boolean
-    public fun setMuted(mute: Boolean)
     public fun mapZoomLevelForCenterMapOnLocation(location: Location): Float
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -25,7 +25,6 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
 
     private var route: Route? = null
     private var isTrackingCurrentLocation: Boolean = true
-    private var muted: Boolean = false
 
     override fun onLocationChanged(location: Location) {
         routeEngine.onLocationChanged(location)
@@ -98,18 +97,6 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
 
     override fun onRouteCancelButtonClick() {
         bus.post(RouteCancelEvent())
-    }
-
-    override fun onMuteClicked() {
-        muted = !muted
-    }
-
-    override fun isMuted(): Boolean {
-        return muted
-    }
-
-    override fun setMuted(isMuted: Boolean) {
-        muted = isMuted
     }
 
     /**

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/VoiceNavigationController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/VoiceNavigationController.kt
@@ -17,7 +17,7 @@ public class VoiceNavigationController(val activity: Activity) {
 
     init {
         val app = activity.application as EraserMapApplication
-        app?.component()?.inject(this@VoiceNavigationController)
+        app.component().inject(this)
         speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD)
     }
 
@@ -83,4 +83,7 @@ public class VoiceNavigationController(val activity: Activity) {
         speakerbox.unmute()
     }
 
+    public fun isMuted(): Boolean {
+        return speakerbox.isMuted
+    }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/VoiceNavigationController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/VoiceNavigationController.kt
@@ -2,16 +2,22 @@ package com.mapzen.erasermap.view
 
 import android.app.Activity
 import android.speech.tts.TextToSpeech
+import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
 import com.mapzen.helpers.RouteEngine
 import com.mapzen.speakerbox.Speakerbox
 import com.mapzen.valhalla.Instruction
 import com.mapzen.valhalla.Router
+import javax.inject.Inject
 
 public class VoiceNavigationController(val activity: Activity) {
-    private val speakerbox = Speakerbox(activity)
+
+    @Inject
+    lateinit var speakerbox: Speakerbox
 
     init {
+        val app = activity.application as EraserMapApplication
+        app?.component()?.inject(this@VoiceNavigationController)
         speakerbox.setQueueMode(TextToSpeech.QUEUE_ADD)
     }
 
@@ -65,7 +71,9 @@ public class VoiceNavigationController(val activity: Activity) {
     public fun playPost(instruction: Instruction): Unit =
             play(instruction.getVerbalPostTransitionInstruction())
 
-    private fun play(text: String): Unit = speakerbox.play(text)
+    private fun play(text: String) {
+        speakerbox.play(text)
+    }
 
     public fun mute() {
         speakerbox.mute()

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -12,6 +12,7 @@ import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
 import com.mapzen.erasermap.presenter.ViewStateManager;
 import com.mapzen.pelias.Pelias;
+import com.mapzen.speakerbox.Speakerbox;
 
 import com.squareup.otto.Bus;
 
@@ -74,5 +75,9 @@ public class TestAndroidModule {
 
     @Provides @Singleton Pelias providePelias() {
         return Mockito.mock(Pelias.class);
+    }
+
+    @Provides @Singleton Speakerbox provideSpeakerbox() {
+        return Mockito.mock(Speakerbox.class);
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -189,4 +189,8 @@ public class TestMainController : MainViewController {
     override fun onBackPressed() {
         popBackStack = true
     }
+
+    override fun stopSpeaker() {
+
+    }
 }


### PR DESCRIPTION
- Make Speakerbox a singleton
- Remove unnecessary mute state handling from RoutePresenter, rely on Speakerbox instead 
- Stop Speakerbox when user cancels routing mode

Depends on: https://github.com/mapzen/speakerbox/pull/8

Closes #408 