### PR TITLE
Reset location tracking flag when route starts

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
@@ -26,4 +26,5 @@ public interface RoutePresenter {
     public fun onMapListToggleClick(state: MapListToggleButton.MapListState)
     public fun onRouteCancelButtonClick()
     public fun mapZoomLevelForCenterMapOnLocation(location: Location): Float
+    public fun isTrackingCurrentLocation(): Boolean
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -36,6 +36,7 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
         currentInstructionIndex = 0
         routeController?.setCurrentInstruction(0)
         routeEngine.route = route
+        isTrackingCurrentLocation = true
     }
 
     override fun onRouteResume(route: Route?) {
@@ -99,6 +100,10 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
         bus.post(RouteCancelEvent())
     }
 
+    override fun isTrackingCurrentLocation(): Boolean {
+        return isTrackingCurrentLocation
+    }
+    
     /**
      * When we center the map on a location we want to dynamically change the map's zoom level.
      * We will zoom the map out if the current maneuver is long and we are still far away from

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -16,6 +16,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.lang.Boolean
 
 @RunWith(RobolectricTestRunner::class)
 public class RoutePresenterTest {
@@ -41,6 +42,15 @@ public class RoutePresenterTest {
         routeEngine.route = route1
         routePresenter.onRouteStart(route2)
         assertThat(routeEngine.route).isEqualTo(route2)
+    }
+
+    @Test fun onRouteStart_shouldResetTrackingLocation() {
+        routePresenter.onRouteStart(Route(getFixture("valhalla_route")))
+        assertThat(routePresenter.isTrackingCurrentLocation()).isTrue()
+        routePresenter.onInstructionPagerTouch()
+        assertThat(routePresenter.isTrackingCurrentLocation()).isFalse()
+        routePresenter.onRouteStart(Route(getFixture("valhalla_route")))
+        assertThat(routePresenter.isTrackingCurrentLocation()).isTrue()
     }
 
     @Test fun onRouteResume_shouldNotResetRouteEngine() {


### PR DESCRIPTION
To repro the bug:
- Start routing
- Touch the screen (get the "resume" button to show)
- Back out of the route
- Start a new route

See that:
- Your current location will not be properly centered in the screen until hitting the resume button

Closes #453