### PR TITLE
Update location marker always, not just when routing

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -752,6 +752,8 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     }
 
     override fun showRoutePreview(location: Location, feature: Feature) {
+        showCurrentLocation(location)
+
         routeManager.origin = location
         routeManager.destination = feature
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -290,6 +290,8 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     @Subscribe public fun onLocationChangeEvent(event: LocationChangeEvent) {
         if (routingEnabled) {
             routeViewController?.onLocationChanged(event.location)
+        } else {
+            mainViewController?.showCurrentLocation(event.location)
         }
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -274,6 +274,21 @@ public class MainPresenterTest {
         assertThat(routeController.location).isNotNull()
     }
 
+    @Test fun onLocationChanged_shouldUpdateCurrentLocationAlways() {
+        mainController.puckPosition = getTestLocation()
+        presenter.routingEnabled = false
+        val location = TestHelper.getTestLocation(40.0, 80.0)
+        presenter.onLocationChangeEvent(LocationChangeEvent(location))
+        assertThat(mainController.puckPosition?.latitude).isEqualTo(location.latitude)
+        assertThat(mainController.puckPosition?.longitude).isEqualTo(location.longitude)
+
+        mainController.puckPosition = getTestLocation()
+        presenter.routingEnabled = true
+        presenter.onLocationChangeEvent(LocationChangeEvent(location))
+        assertThat(mainController.puckPosition?.latitude).isEqualTo(location.latitude)
+        assertThat(mainController.puckPosition?.longitude).isEqualTo(location.longitude)
+    }
+
     @Test fun onSearchResultSelected_shouldCenterOnCurrentFeature() {
         val result = Result()
         val features = ArrayList<Feature>()


### PR DESCRIPTION
- Updates current location when not in route mode
- We were showing the current location in route preview but then it was hidden when navigating back from route mode. This commit shows the current location marker in route preview on navigating back from the route view to the route preview view

Closes #109 