### PR TITLE
Only configure api keys once

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -218,6 +218,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
 
     private fun initMapController() {
         val mapView = findViewById(R.id.map) as MapView
+        mapView.setZOrderMediaOverlay(true) //so that white bg shows, not window when launching
         mapController = MapController(this, mapView, "style/eraser-map.yaml")
         mapController?.setLongPressResponder({
             x, y -> presenter.onReverseGeoRequested(x, y)

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
@@ -35,10 +35,14 @@ public class InitActivity : AppCompatActivity() {
             (findViewById(R.id.build_number) as TextView).text = BuildConfig.BUILD_NUMBER
         }
 
-        Handler().postDelayed({ startMainActivity() }, START_DELAY_IN_MS)
+        if (keys.tilesKey.length > 0) {
+            startMainActivityAndFinish()
+        } else {
+            Handler().postDelayed({ configureKeys() }, START_DELAY_IN_MS)
+        }
     }
 
-    private fun startMainActivity() {
+    private fun configureKeys() {
         if (BuildConfig.VECTOR_TILE_API_KEY == null ||
                 BuildConfig.PELIAS_API_KEY == null ||
                 BuildConfig.VALHALLA_API_KEY == null) {
@@ -54,10 +58,13 @@ public class InitActivity : AppCompatActivity() {
                 keys.searchKey = crypt.decode(BuildConfig.PELIAS_API_KEY)
                 keys.routingKey = crypt.decode(BuildConfig.VALHALLA_API_KEY)
             }
-
-            startActivity(Intent(applicationContext, MainActivity::class.java))
-            finish()
+            startMainActivityAndFinish()
         }
+    }
+
+    private fun startMainActivityAndFinish() {
+        startActivity(Intent(applicationContext, MainActivity::class.java))
+        finish()
     }
 
     private fun initCrashReportService() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -3,6 +3,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:focusableInTouchMode="true"
+    android:background="@color/color_primary"
     tools:context=".MainActivity">
 
     <com.mapzen.tangram.MapView


### PR DESCRIPTION
- Improves perceived launch time on successive launches when application instance hasn't been killed
- Sets `MapView` as a media overlay so that window bg doesn't show on launch (jarring when it does)