### PR TITLE
Fix reversegeo broken after killing navigation from notification

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -1080,7 +1080,6 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
     private fun exitNavigation() {
         initFindMeButton()
         routeModeView.voiceNavigationController?.stop()
-        presenter.routingEnabled = false
         routeModeView.clearRoute()
         routeModeView.route = null
         routeModeView.hideRouteIcon()

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -409,7 +409,7 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     }
 
     override fun onExitNavigation() {
-        vsm.viewState = ViewStateManager.ViewState.SEARCH_RESULTS
+        vsm.viewState = ViewStateManager.ViewState.DEFAULT
         routingEnabled = false;
         routeManager.reverse = false
         onFindMeButtonClick()


### PR DESCRIPTION
- remove redundant call `presenter.routingEnabled = false`
- set `DEFAULT` ViewState when exiting navigation

Closes #349