### PR TITLE
Adds ability to inject search and routing base url at build time

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,9 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'checkstyle'
 
+def SEARCH_BASE_URL = hasProperty('searchBaseUrl') ? '"' + searchBaseUrl + '"' : "null";
+def ROUTE_BASE_URL = hasProperty('routeBaseUrl') ? '"' + routeBaseUrl + '"' : "null";
+
 def VECTOR_TILE_API_KEY = hasProperty('vectorTileApiKey') ? '"' + vectorTileApiKey + '"' : "null";
 def PELIAS_API_KEY = hasProperty('peliasApiKey') ? '"' + peliasApiKey + '"' : "null";
 def VALHALLA_API_KEY = hasProperty('valhallaApiKey') ? '"' + valhallaApiKey + '"' : "null";
@@ -34,6 +37,8 @@ android {
     targetSdkVersion 22
     versionCode buildVersionCode()
     versionName version
+    buildConfigField "String", "SEARCH_BASE_URL", SEARCH_BASE_URL
+    buildConfigField "String", "ROUTE_BASE_URL", ROUTE_BASE_URL
     buildConfigField "String", "VECTOR_TILE_API_KEY", VECTOR_TILE_API_KEY
     buildConfigField "String", "PELIAS_API_KEY", PELIAS_API_KEY
     buildConfigField "String", "VALHALLA_API_KEY", VALHALLA_API_KEY

--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -79,9 +79,11 @@ public class AndroidModule {
     }
 
     @Provides @Singleton Pelias providePelias() {
+        final String endpoint = BuildConfig.SEARCH_BASE_URL != null ?
+                BuildConfig.SEARCH_BASE_URL : Pelias.DEFAULT_SERVICE_ENDPOINT;
         final RestAdapter.LogLevel logLevel = BuildConfig.DEBUG ?
                 RestAdapter.LogLevel.FULL : RestAdapter.LogLevel.NONE;
-        return Pelias.getPelias(logLevel);
+        return Pelias.getPeliasWithEndpoint(endpoint, logLevel);
     }
 
     @Provides @Singleton Speakerbox provideSpeakerbox() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
@@ -1,12 +1,13 @@
 package com.mapzen.erasermap.model
 
 import android.location.Location
-import com.mapzen.pelias.BuildConfig
+import com.mapzen.erasermap.BuildConfig
 import com.mapzen.pelias.SimpleFeature
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import com.mapzen.valhalla.Router
+import com.mapzen.valhalla.ValhallaRouter
 import retrofit.RestAdapter
 
 public class ValhallaRouteManager(val settings: AppSettings,
@@ -79,9 +80,14 @@ public class ValhallaRouteManager(val settings: AppSettings,
     }
 
     private fun getInitializedRouter(type: Router.Type): Router {
+        val endpoint = BuildConfig.ROUTE_BASE_URL ?: ValhallaRouter.DEFAULT_URL
         val logLevel = if (BuildConfig.DEBUG) RestAdapter.LogLevel.FULL else
             RestAdapter.LogLevel.NONE
-        val router = routerFactory.getRouter().setApiKey(apiKey).setLogLevel(logLevel)
+        val router = routerFactory.getRouter()
+                .setApiKey(apiKey)
+                .setEndpoint(endpoint)
+                .setLogLevel(logLevel)
+                .setDntEnabled(true)
         when(type) {
             Router.Type.DRIVING -> return router.setDriving()
             Router.Type.WALKING -> return router.setWalking()

--- a/scripts/deploy-master.sh
+++ b/scripts/deploy-master.sh
@@ -2,6 +2,6 @@
 #
 # Builds master branch and uploads APK to s3://android.mapzen.com/erasermap-snapshots/.
 
-./gradlew assembleDevDebug -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY -PpeliasApiKey=$PELIAS_API_KEY -PvalhallaApiKey=$VALHALLA_API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
+./gradlew assembleDevDebug -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY -PpeliasApiKey=$PELIAS_API_KEY -PvalhallaApiKey=$VALHALLA_API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM -PsearchBaseUrl="$SEARCH_BASE_URL" -ProuteBaseUrl="$ROUTE_BASE_URL"
 s3cmd put app/build/outputs/apk/app-dev-debug.apk s3://android.mapzen.com/erasermap-latest.apk
 s3cmd put app/build/outputs/apk/app-dev-debug.apk s3://android.mapzen.com/erasermap-snapshots/master-$CIRCLE_BUILD_NUM.apk

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,12 +4,12 @@
 
 if [ -z ${PERFORM_RELEASE} ]
   then
-    ./gradlew assembleDevDebug -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY -PpeliasApiKey=$PELIAS_API_KEY -PvalhallaApiKey=$VALHALLA_API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM
+    ./gradlew assembleDevDebug -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY -PpeliasApiKey=$PELIAS_API_KEY -PvalhallaApiKey=$VALHALLA_API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM -PsearchBaseUrl="$SEARCH_BASE_URL" -ProuteBaseUrl="$ROUTE_BASE_URL"
     s3cmd put app/build/outputs/apk/app-dev-debug.apk s3://android.mapzen.com/erasermap-development/$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM.apk
   else
     scripts/install-leyndo.sh
     cd app && git clone $CONFIG_REPO
     cd ..
-    ./gradlew clean assembleProdRelease --refresh-dependencies -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY_PROD -PpeliasApiKey=$PELIAS_API_KEY_PROD -PvalhallaApiKey=$VALHALLA_API_KEY_PROD -PbuildNumber=$RELEASE_TAG -PreleaseStoreFile=$RELEASE_STORE_FILE -PreleaseStorePassword="$RELEASE_STORE_PASSWORD" -PreleaseKeyAlias=$RELEASE_KEY_ALIAS -PreleaseKeyPassword="$RELEASE_KEY_PASSWORD"
+    ./gradlew clean assembleProdRelease --refresh-dependencies -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY_PROD -PpeliasApiKey=$PELIAS_API_KEY_PROD -PvalhallaApiKey=$VALHALLA_API_KEY_PROD -PbuildNumber=$RELEASE_TAG -PreleaseStoreFile=$RELEASE_STORE_FILE -PreleaseStorePassword="$RELEASE_STORE_PASSWORD" -PreleaseKeyAlias=$RELEASE_KEY_ALIAS -PreleaseKeyPassword="$RELEASE_KEY_PASSWORD" -PsearchBaseUrl="$SEARCH_BASE_URL" -ProuteBaseUrl="$ROUTE_BASE_URL"
     s3cmd put app/build/outputs/apk/app-prod-release.apk s3://android.mapzen.com/erasermap-releases/$RELEASE_TAG.apk
 fi


### PR DESCRIPTION
* Updates `build.gradle` to support two new properties: `searchBaseUrl` and `routeBaseUrl`
* Injects base url property values in `BuildConfig.java`
* Uses custom base url values if set when creating `Pelias` and `ValhallaRouter` instance otherwise fall back to default.
* Explicitly enables DNT header for Valhalla requests.

Depends on: https://github.com/mapzen/on-the-road/pull/63

Once merged custom values for search and routing endpoint can be set on Circle CI as needed for production builds. Also allows local builds to point at "dev" server for example simply by updating `gradle.properties`.

cc @baldur 

Fixes #509