### PR TITLE
Kotlin 1.0.0-beta-1103 -> 1.0.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.0-beta-1103'
+  ext.kotlin_version = '1.0.1'
   repositories {
     mavenCentral()
   }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -71,7 +71,7 @@ import retrofit.client.Response
 import java.util.ArrayList
 import javax.inject.Inject
 
-public class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
+class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
         SearchResultsView.OnSearchResultSelectedListener {
 
     companion object {
@@ -83,8 +83,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         @JvmStatic val MAP_DATA_PROP_NAME = "name"
     }
 
-    public val requestCodeSearchResults: Int = 0x01
-
+    val requestCodeSearchResults: Int = 0x01
 
     @Inject lateinit var savedSearch: SavedSearch
     @Inject lateinit var presenter: MainPresenter
@@ -358,10 +357,10 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         menuInflater.inflate(R.menu.menu_main, menu)
         optionsMenu = menu
         searchView = PeliasSearchView(this)
-        supportActionBar.setCustomView(searchView,ActionBar.LayoutParams(
+        supportActionBar?.setCustomView(searchView,ActionBar.LayoutParams(
                 ActionBar.LayoutParams.MATCH_PARENT, ActionBar.LayoutParams.WRAP_CONTENT))
-        supportActionBar.displayOptions = supportActionBar.displayOptions or
-                ActionBar.DISPLAY_SHOW_CUSTOM
+        val displayOptions = supportActionBar?.displayOptions ?:0
+        supportActionBar?.displayOptions = displayOptions or ActionBar.DISPLAY_SHOW_CUSTOM
         val emptyView = findViewById(android.R.id.empty)
         autocompleteListView.hideHeader()
 
@@ -402,7 +401,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
 
     override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
         val prefs: SharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
-        val cacheSearches = prefs?.getBoolean(AndroidAppSettings.KEY_CACHE_SEARCH_HISTORY, true)
+        val cacheSearches = prefs.getBoolean(AndroidAppSettings.KEY_CACHE_SEARCH_HISTORY, true)
         searchView?.setCacheSearchResults(cacheSearches)
         return true
     }
@@ -457,7 +456,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         presenter.resultListVisible = false
         optionsMenu?.findItem(R.id.action_view_all)?.setIcon(R.drawable.ic_list)
         searchView?.onActionViewCollapsed()
-        searchView?.setIconified(false)
+        searchView?.isIconified = false
         searchView?.clearFocus()
         searchView?.disableAutoComplete()
         searchView?.setQuery(presenter.currentSearchTerm, false)
@@ -477,7 +476,7 @@ public class MainActivity : AppCompatActivity(), MainViewController, RouteCallba
         val term = presenter.currentSearchTerm
         if (term != null) {
             searchView.setQuery(term, false)
-            if (searchResultsView.visibility == View.VISIBLE && presenter?.reverseGeo == false) {
+            if (searchResultsView.visibility == View.VISIBLE && presenter.reverseGeo == false) {
                 searchView.clearFocus()
                 showActionViewAll()
             } else {

--- a/app/src/main/kotlin/com/mapzen/erasermap/util/DouglasPeuckerReducer.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/util/DouglasPeuckerReducer.kt
@@ -13,7 +13,7 @@ import android.location.Location
  * * Modified by baldur@mapzen.com
  * * Converted to kotlin by peter.jasko@mapzen.com
  */
-public object DouglasPeuckerReducer {
+object DouglasPeuckerReducer {
 
     /**
      * Reduce the number of points in a shape using the Douglas-Peucker
@@ -28,8 +28,8 @@ public object DouglasPeuckerReducer {
      * *
      * @return the reduced shape
      */
-    public fun reduceWithTolerance(shape: List<Location>, tolerance: Double): List<Location> {
-        val n = shape.size()
+    fun reduceWithTolerance(shape: List<Location>, tolerance: Double): List<Location> {
+        val n = shape.size
         // if a shape has 2 or less points it cannot be reduced
         if (tolerance <= 0 || n < 3) {
             return shape
@@ -138,7 +138,7 @@ public object DouglasPeuckerReducer {
      * *
      * @return The distance in points coordinate system
      */
-    public fun orthogonalDistance(point: Location, lineStart: Location, lineEnd: Location): Double {
+    fun orthogonalDistance(point: Location, lineStart: Location, lineEnd: Location): Double {
         val area = Math.abs((1.0 * lineStart.getLatitude() * 1e6 * lineEnd.getLongitude() * 1e6+1.0 * lineEnd.getLatitude() * 1e6 * point.getLongitude() * 1e6+1.0 * point.getLatitude() * 1e6 * lineStart.getLongitude() * 1e6-1.0 * lineEnd.getLatitude() * 1e6 * lineStart.getLongitude() * 1e6-1.0 * point.getLatitude() * 1e6* lineEnd.getLongitude() * 1e6-1.0 * lineStart.getLatitude() * 1e6 * point.getLongitude() * 1e6)/2.0)
 
         val bottom = Math.hypot(lineStart.getLatitude() * 1e6 - lineEnd.getLatitude() * 1e6, lineStart.getLongitude() * 1e6-lineEnd.getLongitude() * 1e6)

--- a/app/src/main/kotlin/com/mapzen/erasermap/util/NotificationCreator.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/util/NotificationCreator.kt
@@ -16,7 +16,7 @@ import com.mapzen.erasermap.R
 import com.mapzen.erasermap.service.NotificationService
 import com.mapzen.erasermap.controller.MainActivity
 
-public class NotificationCreator(private val mainActivity: Activity) {
+class NotificationCreator(private val mainActivity: Activity) {
     private var builder: NotificationCompat.Builder? = null
     private var bigTextStyle: NotificationCompat.BigTextStyle? = null
     private var stackBuilder: TaskStackBuilder? = null
@@ -30,8 +30,8 @@ public class NotificationCreator(private val mainActivity: Activity) {
     private val serviceIntent: Intent
 
     companion object {
-        val EXIT_NAVIGATION = "exit_navigation"
-        val NOTIFICATION_TAG_ROUTE = "route"
+        const val EXIT_NAVIGATION = "exit_navigation"
+        const val NOTIFICATION_TAG_ROUTE = "route"
     }
 
     init {
@@ -103,7 +103,7 @@ public class NotificationCreator(private val mainActivity: Activity) {
         builder?.setOngoing(true)
     }
 
-    public fun killNotification() {
+    fun killNotification() {
         notificationManager.cancelAll()
         serviceConnection.service?.stopService(serviceIntent)
     }
@@ -113,8 +113,8 @@ public class NotificationCreator(private val mainActivity: Activity) {
      */
     private class NotificationServiceConnection: ServiceConnection {
 
-        public val activity: Activity
-        public var service: NotificationService? = null
+        val activity: Activity
+        var service: NotificationService? = null
 
         constructor(activity: Activity) {
             this.activity = activity
@@ -127,7 +127,7 @@ public class NotificationCreator(private val mainActivity: Activity) {
             val binder = inBinder as NotificationService.NotificationBinder
             val intent: Intent = Intent(activity, NotificationService::class.java)
             this.service = binder.service
-            binder.service?.startService(intent)
+            binder.service.startService(intent)
         }
 
         override fun onServiceDisconnected(component: ComponentName?) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/DirectionListAdapter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/DirectionListAdapter.kt
@@ -10,13 +10,13 @@ import com.mapzen.erasermap.R
 import com.mapzen.erasermap.util.DisplayHelper
 import java.util.ArrayList
 
-public class DirectionListAdapter(val context: Context, val strings: ArrayList<String>?,
+class DirectionListAdapter(val context: Context, val strings: ArrayList<String>?,
         val types: ArrayList<Int>?, val distances: ArrayList<Int>?,
         val reverse : Boolean?, val showCurrentLocation : Boolean = true) : BaseAdapter() {
 
     private final var CURRENT_LOCATION_OFFSET =  1
 
-    public var currentInstructionIndex: Int = 0
+    var currentInstructionIndex: Int = 0
 
     override fun getCount(): Int {
         val size = strings?.size ?: 0
@@ -49,7 +49,7 @@ public class DirectionListAdapter(val context: Context, val strings: ArrayList<S
     }
 
     private fun setReversedDirectionListItem(position : Int, view : View)  {
-        if(position == strings?.size()) {
+        if(position == strings?.size) {
             setListItemToCurrentLocation(view)
         } else {
             val distance = distances?.get(position) ?: 0

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/HomeAsUpActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/HomeAsUpActivity.kt
@@ -7,7 +7,7 @@ import android.view.MenuItem
 open class HomeAsUpActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
     }
 
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
@@ -15,7 +15,7 @@ import com.mapzen.erasermap.model.ApiKeys
 import com.mapzen.erasermap.model.SimpleCrypt
 import javax.inject.Inject
 
-public class InitActivity : AppCompatActivity() {
+class InitActivity : AppCompatActivity() {
     companion object {
         @JvmStatic public val START_DELAY_IN_MS: Long = 1200
     }
@@ -29,7 +29,7 @@ public class InitActivity : AppCompatActivity() {
         app.component()?.inject(this)
         initCrashReportService()
         setContentView(R.layout.splash_screen)
-        supportActionBar.hide()
+        supportActionBar?.hide()
 
         if (BuildConfig.DEBUG) {
             (findViewById(R.id.build_number) as TextView).text = BuildConfig.BUILD_NUMBER

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -34,7 +34,7 @@ import com.mapzen.valhalla.Router
 import java.util.ArrayList
 import javax.inject.Inject
 
-public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPageChangeListener {
+class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPageChangeListener {
     companion object {
         const val VIEW_TAG: String = "Instruction_"
         const val MAP_DATA_NAME_ROUTE_ICON = "route_icon"
@@ -44,21 +44,37 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
         const val MAP_DATA_PROP_LINE = "line"
     }
 
-    val mapListToggle: MapListToggleButton by lazy { findViewById(R.id.map_list_toggle) as MapListToggleButton }
-    val routeCancelButton: ImageView by lazy { findViewById(R.id.route_cancel) as ImageView }
-    val directionListView: DirectionListView by lazy { findViewById(R.id.direction_list_vew) as DirectionListView }
-    val distanceToDestination: DistanceView by lazy { findViewById(R.id.destination_distance) as DistanceView }
-    val instructionPager: ViewPager by lazy { findViewById(R.id.instruction_pager) as ViewPager }
-    val resumeButton: Button by lazy { findViewById(R.id.resume) as Button }
-    val destinationNameTextView: TextView by lazy { findViewById(R.id.destination_name) as TextView }
+    val mapListToggle: MapListToggleButton by lazy {
+        findViewById(R.id.map_list_toggle)as MapListToggleButton
+    }
+    val routeCancelButton: ImageView by lazy {
+        findViewById(R.id.route_cancel) as ImageView
+    }
+    val directionListView: DirectionListView by lazy {
+        findViewById(R.id.direction_list_vew) as DirectionListView
+    }
+    val distanceToDestination: DistanceView by lazy {
+        findViewById(R.id.destination_distance) as DistanceView
+    }
+    val instructionPager: ViewPager by lazy {
+        findViewById(R.id.instruction_pager) as ViewPager
+    }
+    val resumeButton: Button by lazy {
+        findViewById(R.id.resume) as Button
+    }
+    val destinationNameTextView: TextView by lazy {
+        findViewById(R.id.destination_name) as TextView
+    }
 
     var mapController: MapController? = null
         set(value) {
             value?.setPanResponder(object: TouchInput.PanResponder {
-                override fun onPan(startX: Float, startY: Float, endX: Float, endY: Float): Boolean {
+                override fun onPan(startX: Float, startY: Float, endX: Float, endY: Float):
+                        Boolean {
                     return onMapPan(endX - startX, endY - startY)
                 }
-                override fun onFling(posX: Float, posY: Float, velocityX: Float, velocityY: Float): Boolean {
+                override fun onFling(posX: Float, posY: Float, velocityX: Float, velocityY: Float):
+                        Boolean {
                     return false
                 }
             })
@@ -104,7 +120,9 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
             instructionPager.currentItem = routePresenter.currentInstructionIndex ?: 0
         }
 
-        mapListToggle.setOnClickListener { routePresenter.onMapListToggleClick(mapListToggle.state) }
+        mapListToggle.setOnClickListener {
+            routePresenter.onMapListToggleClick(mapListToggle.state)
+        }
         routeCancelButton.setOnClickListener { routePresenter.onRouteCancelButtonClick() }
     }
 
@@ -268,16 +286,19 @@ public class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPage
             val screenWidth = point.x.toDouble()
             val screenHeight = point.y.toDouble()
 
-            // Find the view that will place the current location marker in the lower quarter of the window
-            val nextPosition = mapController?.coordinatesAtScreenPosition(screenWidth/2, screenHeight/3.5) ?: LngLat()
+            // Find the view that will place the current location marker in the lower quarter
+            // of the window.
+            val nextPosition = mapController?.coordinatesAtScreenPosition(screenWidth/2,
+                    screenHeight/3.5) ?: LngLat()
             val nextRotation = getBearingInRadians(location)
 
             // Return to our initial view to prepare for easing to the next view
             mapController?.mapPosition = lastPosition
-            mapController?.mapRotation = lastRotation
+            mapController?.mapRotation = lastRotation ?: 0f
 
             // Begin easing to the next view
-            mapController?.setMapPosition(nextPosition.longitude, nextPosition.latitude, 1f, MapController.EaseType.LINEAR)
+            mapController?.setMapPosition(nextPosition.longitude, nextPosition.latitude, 1f,
+                    MapController.EaseType.LINEAR)
             mapController?.setMapRotation(nextRotation, 1f, MapController.EaseType.LINEAR)
         }
     }

--- a/app/src/test/java/com/mapzen/erasermap/view/RouteModeViewTest.java
+++ b/app/src/test/java/com/mapzen/erasermap/view/RouteModeViewTest.java
@@ -40,6 +40,7 @@ import android.widget.TextView;
 
 import java.util.List;
 
+import static android.content.Context.NOTIFICATION_SERVICE;
 import static com.mapzen.erasermap.dummy.TestHelper.getFixture;
 import static com.mapzen.erasermap.dummy.TestHelper.getTestFeature;
 import static com.mapzen.erasermap.dummy.TestHelper.getTestLocation;
@@ -275,8 +276,6 @@ public class RouteModeViewTest {
         ShadowNotification sNotification = Shadows.shadowOf(sManager.getAllNotifications().get(0));
         assertThat(sNotification.getContentTitle()).isEqualTo("Name");
         assertThat(sNotification.getContentText()).isEqualTo("Go north on Adalbertstraße.");
-        NotificationManager manager = (NotificationManager) startActivity.getSystemService(
-                Context.NOTIFICATION_SERVICE);
         assertThat(sManager.getAllNotifications().get(0).actions[0].title)
                 .isEqualTo("Exit Navigation");
     }
@@ -297,10 +296,9 @@ public class RouteModeViewTest {
     }
 
     private ShadowNotificationManager getRoutingNotificationManager() {
-        NotificationManager manager = (NotificationManager) startActivity.getSystemService(
-                Context.NOTIFICATION_SERVICE);
-        ShadowNotificationManager sManager = Shadows.shadowOf(manager);
-        return sManager;
+        NotificationManager manager = (NotificationManager)
+                startActivity.getSystemService(NOTIFICATION_SERVICE);
+        return Shadows.shadowOf(manager);
     }
 
     class TestViewGroup extends ViewGroup {

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/MainActivityTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/MainActivityTest.kt
@@ -120,7 +120,7 @@ public class MainActivityTest {
     public fun onDestroy_shouldSetCurrentSearchTerm() {
         val menu = RoboMenu()
         activity.onCreateOptionsMenu(menu)
-        val searchView = activity.supportActionBar.customView as SearchView
+        val searchView = activity.supportActionBar!!.customView as SearchView
         searchView.setQuery("query", false)
         searchView.requestFocus()
         activity.onDestroy()
@@ -133,7 +133,7 @@ public class MainActivityTest {
         activity.onCreateOptionsMenu(menu)
         activity.presenter!!.currentSearchTerm = "query"
         activity.onCreateOptionsMenu(menu)
-        val searchView = activity.supportActionBar.customView as SearchView
+        val searchView = activity.supportActionBar!!.customView as SearchView
         assertThat(searchView.query).isEqualTo("query")
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -1,5 +1,6 @@
 package com.mapzen.erasermap.presenter
 
+import android.location.Location
 import com.mapzen.erasermap.dummy.TestHelper
 import com.mapzen.erasermap.dummy.TestHelper.getTestFeature
 import com.mapzen.erasermap.dummy.TestHelper.getTestLocation
@@ -28,7 +29,7 @@ import org.junit.Before
 import org.junit.Test
 import java.util.ArrayList
 
-public class MainPresenterTest {
+class MainPresenterTest {
     private val mainController: TestMainController = TestMainController()
     private val routeController: TestRouteController = TestRouteController()
     private val mapzenLocation: TestMapzenLocation = TestMapzenLocation()
@@ -356,14 +357,14 @@ public class MainPresenterTest {
         presenter.onCreate()
         mainController.location = null
         presenter.onCreate()
-        assertThat(mainController.location).isNull()
+        assertThat(mainController.location as Location?).isNull()
     }
 
     @Test fun onCreate_shouldShowCurrentLocationSecondTimeInvoked() {
         presenter.onCreate()
         mainController.puckPosition = null
         presenter.onCreate()
-        assertThat(mainController.puckPosition).isNotNull()
+        assertThat(mainController.puckPosition as Location).isNotNull()
     }
 
     @Test fun onReroute_shouldShowProgress() {
@@ -421,7 +422,7 @@ public class MainPresenterTest {
         mainController.routeLine = null
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
         presenter.success(route)
-        assertThat(mainController.routeLine).isEqualTo(route)
+        assertThat(mainController.routeLine as Route).isEqualTo(route)
     }
 
     @Test fun onRerouteSuccess_shouldNotResetMute() {
@@ -496,7 +497,7 @@ public class MainPresenterTest {
     }
 
     class RouteEventSubscriber {
-        public var event: RouteEvent? = null
+        var event: RouteEvent? = null
 
         @Subscribe fun onRouteEvent(event: RouteEvent) {
             this.event = event

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/HomeAsUpActivityTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/HomeAsUpActivityTest.kt
@@ -1,42 +1,37 @@
 package com.mapzen.erasermap.view
 
-import android.app.ActionBar
+import android.app.ActionBar.DISPLAY_HOME_AS_UP
 import com.mapzen.erasermap.BuildConfig
 import com.mapzen.erasermap.PrivateMapsTestRunner
+import com.mapzen.erasermap.R
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric.setupActivity
 import org.robolectric.annotation.Config
-import android.app.ActionBar.DISPLAY_HOME_AS_UP
-import com.mapzen.erasermap.R
 import org.robolectric.fakes.RoboMenuItem
 
 @RunWith(PrivateMapsTestRunner::class)
 @Config(constants = BuildConfig::class, sdk=intArrayOf(21))
-public class HomeAsUpActivityTest {
+class HomeAsUpActivityTest {
     var homeAsUpActivity = setupActivity(HomeAsUpActivity::class.java)
 
-    @Test
-    public fun shouldNotBeNull() {
+    @Test fun shouldNotBeNull() {
         assertThat(homeAsUpActivity).isNotNull()
     }
 
-    @Test
-    public fun shouldDisplayHomeAsUpEnabled() {
-        val displayOptions = homeAsUpActivity.getSupportActionBar().getDisplayOptions()
+    @Test fun shouldDisplayHomeAsUpEnabled() {
+        val displayOptions = homeAsUpActivity.supportActionBar!!.displayOptions
         assertThat(displayOptions and DISPLAY_HOME_AS_UP).isEqualTo(DISPLAY_HOME_AS_UP)
     }
 
-    @Test
-    public fun shouldFinishOnHomeSelected() {
+    @Test fun shouldFinishOnHomeSelected() {
         homeAsUpActivity.onOptionsItemSelected(RoboMenuItem(android.R.id.home))
-        assertThat(homeAsUpActivity.isFinishing()).isTrue()
+        assertThat(homeAsUpActivity.isFinishing).isTrue()
     }
 
-    @Test
-    public fun shouldNotFinishIfOtherOptionSelected() {
+    @Test fun shouldNotFinishIfOtherOptionSelected() {
         homeAsUpActivity.onOptionsItemSelected(RoboMenuItem(R.id.action_settings))
-        assertThat(homeAsUpActivity.isFinishing()).isFalse()
+        assertThat(homeAsUpActivity.isFinishing).isFalse()
     }
 }


### PR DESCRIPTION
Syntax updates:
* Removes redundant `public` modifier from classes and properties where implied
* Adds nullability check `?.` where needed in app code (prevents crashes in production code)
* Adds forced dereference `!!.` where needed in tests (tests should crash if `null` is encountered unexpectedly)
* Uses property access syntax for java setter/getter (ex. `searchView?.setIconified(false)` -> `searchView?.isIconified = false`)
* Adds 'const' modifier to constant values contained in `companion object`s
* Wrap lines at 100 characters
* Cast values in `assertThat(...)` methods to avoid ambiguous method call errors

Depends on https://github.com/mapzen/on-the-road/pull/53

Closes #320