### PR TITLE
Move currentSnapLocation to RoutePresenter

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
@@ -6,26 +6,27 @@ import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.valhalla.Instruction
 import com.mapzen.valhalla.Route
 
-public interface RoutePresenter {
+interface RoutePresenter {
     companion object {
-        public val GESTURE_MIN_DELTA = 0.0001f
+        val GESTURE_MIN_DELTA = 0.0001f
     }
 
-    public var routeController: RouteViewController?
-    public var currentInstructionIndex: Int
+    var routeController: RouteViewController?
+    var currentInstructionIndex: Int
+    var currentSnapLocation: Location?
 
-    public fun onLocationChanged(location: Location)
-    public fun onRouteStart(route: Route?)
-    public fun onRouteResume(route: Route?)
-    public fun onMapPan(deltaX: Float, deltaY: Float)
-    public fun onResumeButtonClick()
-    public fun onInstructionPagerTouch()
-    public fun onInstructionSelected(instruction: Instruction)
-    public fun onUpdateSnapLocation(location: Location)
-    public fun onRouteClear()
-    public fun onMapListToggleClick(state: MapListToggleButton.MapListState)
-    public fun onRouteCancelButtonClick()
-    public fun mapZoomLevelForCenterMapOnLocation(location: Location): Float
-    public fun isTrackingCurrentLocation(): Boolean
-    public fun onSetCurrentInstruction(index: Int)
+    fun onLocationChanged(location: Location)
+    fun onRouteStart(route: Route?)
+    fun onRouteResume(route: Route?)
+    fun onMapPan(deltaX: Float, deltaY: Float)
+    fun onResumeButtonClick()
+    fun onInstructionPagerTouch()
+    fun onInstructionSelected(instruction: Instruction)
+    fun onUpdateSnapLocation(location: Location)
+    fun onRouteClear()
+    fun onMapListToggleClick(state: MapListToggleButton.MapListState)
+    fun onRouteCancelButtonClick()
+    fun mapZoomLevelForCenterMapOnLocation(location: Location): Float
+    fun isTrackingCurrentLocation(): Boolean
+    fun onSetCurrentInstruction(index: Int)
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -10,7 +10,7 @@ import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.Router
 import com.squareup.otto.Bus
 
-public class RoutePresenterImpl(private val routeEngine: RouteEngine,
+class RoutePresenterImpl(private val routeEngine: RouteEngine,
         private val routeEngineListener: RouteEngineListener,
         private val bus: Bus,
         private val vsm: ViewStateManager) : RoutePresenter {
@@ -22,6 +22,7 @@ public class RoutePresenterImpl(private val routeEngine: RouteEngine,
         }
 
     override var currentInstructionIndex: Int = 0
+    override var currentSnapLocation: Location? = null
 
     private var route: Route? = null
     private var isTrackingCurrentLocation: Boolean = true


### PR DESCRIPTION
- Persist currentSnapLocation across screen rotations
- Center map if device rotated in route mode
- Some Kotlin 1.0.1 cleanup