### PR TITLE
Update style submodule and fix double vector tile API key params

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -311,7 +311,7 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     }
 
     private fun initFindMeButton() {
-        findMe = MapData("find_me")
+        findMe = MapData("mz_current_location")
         Tangram.addDataSource(findMe)
         findMeButton.visibility = View.VISIBLE
         findMeButton.setOnClickListener({ presenter.onFindMeButtonClick() })
@@ -628,7 +628,7 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
         val properties = com.mapzen.tangram.Properties()
         properties.set(MAP_DATA_PROP_STATE, MAP_DATA_PROP_STATE_ACTIVE)
         if (reverseGeocodeData == null) {
-            reverseGeocodeData = MapData("reverse_geocode")
+            reverseGeocodeData = MapData("mz_dropped_pin")
             Tangram.addDataSource(reverseGeocodeData)
         }
         reverseGeocodeData?.clear()
@@ -654,7 +654,7 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
 
         // hijack reverseGeocodeData for tappedPoiPin
         if (reverseGeocodeData == null) {
-            reverseGeocodeData = MapData("reverse_geocode")
+            reverseGeocodeData = MapData("mz_dropped_pin")
             Tangram.addDataSource(reverseGeocodeData)
         }
         reverseGeocodeData?.clear()
@@ -674,7 +674,7 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
         centerOnCurrentFeature(features)
 
         if (searchResultsData == null) {
-            searchResultsData = MapData("search")
+            searchResultsData = MapData("mz_search_result")
             Tangram.addDataSource(searchResultsData)
         }
 
@@ -912,8 +912,8 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     }
 
     private fun showRoutePins(start: LngLat, end: LngLat) {
-        startPin = MapData("route_start")
-        endPin = MapData("route_stop")
+        startPin = MapData("mz_route_start")
+        endPin = MapData("mz_route_stop")
         Tangram.addDataSource(startPin)
         Tangram.addDataSource(endPin)
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -38,8 +38,8 @@ import javax.inject.Inject
 class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPageChangeListener, DirectionItemClickListener {
     companion object {
         const val VIEW_TAG: String = "Instruction_"
-        const val MAP_DATA_NAME_ROUTE_ICON = "route_icon"
-        const val MAP_DATA_NAME_ROUTE_LINE = "route"
+        const val MAP_DATA_NAME_ROUTE_ICON = "mz_route_location"
+        const val MAP_DATA_NAME_ROUTE_LINE = "mz_route_line"
         const val MAP_DATA_PROP_TYPE = "type"
         const val MAP_DATA_PROP_POINT = "point"
         const val MAP_DATA_PROP_LINE = "line"


### PR DESCRIPTION
Fixes issue where two API keys were included on each vector tile request (one from the stylesheet and one injected in code at runtime).

* Updates stylesheet submodule to `no-api-key` branch
* Update client data source names to use `mz_*` namespacing

Closes #552