### PR TITLE
Better API key management

### DIFF
--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -2,7 +2,6 @@ package com.mapzen.erasermap;
 
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.erasermap.model.AndroidAppSettings;
-import com.mapzen.erasermap.model.ApiKeys;
 import com.mapzen.erasermap.model.AppSettings;
 import com.mapzen.erasermap.model.MapzenLocation;
 import com.mapzen.erasermap.model.MapzenLocationImpl;
@@ -63,16 +62,16 @@ public class AndroidModule {
         return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm);
     }
 
-    @Provides @Singleton RouteManager provideRouteManager(AppSettings settings, ApiKeys keys) {
+    @Provides @Singleton RouteManager provideRouteManager(AppSettings settings) {
         final ValhallaRouteManager manager = new ValhallaRouteManager(settings,
                 new ValhallaRouterFactory());
-        manager.setApiKey(keys.getRoutingKey());
+        manager.setApiKey(application.getApiKeys().getRoutingKey());
         return manager;
     }
 
-    @Provides @Singleton TileHttpHandler provideTileHttpHandler(ApiKeys keys) {
+    @Provides @Singleton TileHttpHandler provideTileHttpHandler() {
         final TileHttpHandler handler = new TileHttpHandler(application);
-        handler.setApiKey(keys.getTilesKey());
+        handler.setApiKey(application.getApiKeys().getTilesKey());
         return handler;
     }
 

--- a/app/src/main/java/com/mapzen/erasermap/CommonModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/CommonModule.java
@@ -1,6 +1,5 @@
 package com.mapzen.erasermap;
 
-import com.mapzen.erasermap.model.ApiKeys;
 import com.mapzen.erasermap.presenter.RouteEngineListener;
 import com.mapzen.erasermap.presenter.RoutePresenter;
 import com.mapzen.erasermap.presenter.RoutePresenterImpl;
@@ -36,9 +35,5 @@ public class CommonModule {
 
     @Provides @Singleton ViewStateManager provideViewStateManager() {
         return new ViewStateManager();
-    }
-
-    @Provides @Singleton ApiKeys provideApiKeys() {
-        return new ApiKeys("", "", "");
     }
 }

--- a/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
+++ b/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap;
 
 import com.mapzen.erasermap.controller.MainActivity;
+import com.mapzen.erasermap.model.ApiKeys;
 import com.mapzen.erasermap.receiver.MockLocationReceiver;
 import com.mapzen.erasermap.view.DistanceView;
 import com.mapzen.erasermap.view.InitActivity;
@@ -9,6 +10,9 @@ import com.mapzen.erasermap.view.SearchResultsAdapter;
 import com.mapzen.erasermap.view.SettingsActivity;
 import com.mapzen.erasermap.view.ViewAboutPreference;
 import com.mapzen.erasermap.view.VoiceNavigationController;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import android.app.Application;
 
@@ -33,6 +37,7 @@ public class EraserMapApplication extends Application {
 
     private ApplicationComponent component;
     private boolean isVisible = true;
+    private ApiKeys apiKeys;
 
     @Override
     public void onCreate() {
@@ -56,5 +61,13 @@ public class EraserMapApplication extends Application {
 
     public ApplicationComponent component() {
         return component;
+    }
+
+    public @Nullable ApiKeys getApiKeys() {
+        return apiKeys;
+    }
+
+    public void setApiKeys(@NotNull ApiKeys apiKeys) {
+        this.apiKeys = apiKeys;
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -32,7 +32,6 @@ import com.mapzen.erasermap.CrashReportService
 import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
 import com.mapzen.erasermap.model.AndroidAppSettings
-import com.mapzen.erasermap.model.ApiKeys
 import com.mapzen.erasermap.model.AppSettings
 import com.mapzen.erasermap.model.ConfidenceHandler
 import com.mapzen.erasermap.model.MapzenLocation
@@ -108,7 +107,6 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     @Inject lateinit var settings: AppSettings
     @Inject lateinit var tileHttpHandler: TileHttpHandler
     @Inject lateinit var mapzenLocation: MapzenLocation
-    @Inject lateinit var keys: ApiKeys
     @Inject lateinit var pelias: Pelias
     @Inject lateinit var speaker: Speaker
     @Inject lateinit var permissionManager: PermissionManager
@@ -430,7 +428,7 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
         initAutoCompleteAdapter()
         autocompleteListView.adapter = autoCompleteAdapter
         pelias.setLocationProvider(presenter.getPeliasLocationProvider())
-        pelias.setApiKey(keys.searchKey)
+        pelias.setApiKey(app.apiKeys?.searchKey)
         searchView?.setAutoCompleteListView(autocompleteListView)
         searchView?.setSavedSearch(savedSearch)
         searchView?.setPelias(pelias)

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
@@ -4,6 +4,13 @@ package com.mapzen.erasermap.model
  * Wrangle API keys for Mapzen services
  */
 data class ApiKeys(
-        public var tilesKey: String,
-        public var searchKey: String,
-        public var routingKey: String)
+        val tilesKey: String,
+        val searchKey: String,
+        val routingKey: String) {
+
+    init {
+        if (tilesKey.isEmpty()) throw IllegalArgumentException("Tiles key cannot be empty.")
+        if (searchKey.isEmpty()) throw IllegalArgumentException("Search key cannot be empty.")
+        if (routingKey.isEmpty()) throw IllegalArgumentException("Routing key cannot be empty.")
+    }
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
@@ -21,11 +21,12 @@ class InitActivity : AppCompatActivity() {
     }
 
     @Inject lateinit var crashReportService: CrashReportService
-    @Inject lateinit var keys: ApiKeys
+
+    lateinit var app: EraserMapApplication
 
     override public fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val app = application as EraserMapApplication
+        app = application as EraserMapApplication
         app.component()?.inject(this)
         initCrashReportService()
         setContentView(R.layout.splash_screen)
@@ -35,7 +36,7 @@ class InitActivity : AppCompatActivity() {
             (findViewById(R.id.build_number) as TextView).text = BuildConfig.BUILD_NUMBER
         }
 
-        if (keys.tilesKey.length > 0) {
+        if (app.apiKeys != null) {
             startMainActivityAndFinish()
         } else {
             Handler().postDelayed({ configureKeys() }, START_DELAY_IN_MS)
@@ -49,14 +50,16 @@ class InitActivity : AppCompatActivity() {
             showApiKeyDialog()
         } else {
             if (BuildConfig.DEBUG) {
-                keys.tilesKey = BuildConfig.VECTOR_TILE_API_KEY
-                keys.searchKey = BuildConfig.PELIAS_API_KEY
-                keys.routingKey = BuildConfig.VALHALLA_API_KEY
+                val tilesKey = BuildConfig.VECTOR_TILE_API_KEY
+                val searchKey = BuildConfig.PELIAS_API_KEY
+                val routingKey = BuildConfig.VALHALLA_API_KEY
+                app.setApiKeys(ApiKeys(tilesKey, searchKey, routingKey))
             } else {
                 val crypt = SimpleCrypt(application)
-                keys.tilesKey = crypt.decode(BuildConfig.VECTOR_TILE_API_KEY)
-                keys.searchKey = crypt.decode(BuildConfig.PELIAS_API_KEY)
-                keys.routingKey = crypt.decode(BuildConfig.VALHALLA_API_KEY)
+                val tilesKey = crypt.decode(BuildConfig.VECTOR_TILE_API_KEY)
+                val searchKey = crypt.decode(BuildConfig.PELIAS_API_KEY)
+                val routingKey = crypt.decode(BuildConfig.VALHALLA_API_KEY)
+                app.setApiKeys(ApiKeys(tilesKey, searchKey, routingKey))
             }
             startMainActivityAndFinish()
         }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
@@ -1,0 +1,24 @@
+package com.mapzen.erasermap.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ApiKeysTest {
+    val apiKeys = ApiKeys("vector-tiles-test", "search-test", "valhalla-test")
+
+    @Test fun shouldNotBeNull() {
+        assertThat(apiKeys).isNotNull()
+    }
+
+    @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptyTilesKey() {
+        ApiKeys("", "search-test", "valhalla-test")
+    }
+
+    @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptySearchKey() {
+        ApiKeys("vector-tiles-test", "", "valhalla-test")
+    }
+
+    @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptyRoutingKey() {
+        ApiKeys("vector-tiles-test", "search-test", "")
+    }
+}


### PR DESCRIPTION
Attempts to prevent loss of API keys when app is put into background and later resumed.

* Makes API keys a member of application class
* Disallows empty strings in API key object constructor

These changes are meant to:
1. Prevent loss of the `ApiKeys` object instance by making it a member of the application class which should persist as long as the process is alive.
2. Fail fast if empty API keys are attempted to be set by throwing an `IllegalArgumentException`.

Fixes #555 