### PR TITLE
Handle implicit intents

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,8 +32,26 @@
             android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data android:scheme="geo" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data
+                    android:scheme="http"
+                    android:host="maps.google.com" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <data
+                    android:scheme="https"
+                    android:host="maps.google.com" />
+                <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
         <receiver android:name=".receiver.MockLocationReceiver">

--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -3,6 +3,7 @@ package com.mapzen.erasermap;
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.erasermap.model.AndroidAppSettings;
 import com.mapzen.erasermap.model.AppSettings;
+import com.mapzen.erasermap.model.IntentQueryParser;
 import com.mapzen.erasermap.model.MapzenLocation;
 import com.mapzen.erasermap.model.MapzenLocationImpl;
 import com.mapzen.erasermap.model.PermissionManager;
@@ -58,8 +59,10 @@ public class AndroidModule {
     }
 
     @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation, Bus bus,
-            RouteManager routeManager, AppSettings settings, ViewStateManager vsm) {
-        return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm);
+            RouteManager routeManager, AppSettings settings, ViewStateManager vsm,
+            IntentQueryParser intentQueryParser) {
+        return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm,
+                intentQueryParser);
     }
 
     @Provides @Singleton RouteManager provideRouteManager(AppSettings settings) {

--- a/app/src/main/java/com/mapzen/erasermap/CommonModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/CommonModule.java
@@ -1,5 +1,6 @@
 package com.mapzen.erasermap;
 
+import com.mapzen.erasermap.model.IntentQueryParser;
 import com.mapzen.erasermap.presenter.RouteEngineListener;
 import com.mapzen.erasermap.presenter.RoutePresenter;
 import com.mapzen.erasermap.presenter.RoutePresenterImpl;
@@ -35,5 +36,9 @@ public class CommonModule {
 
     @Provides @Singleton ViewStateManager provideViewStateManager() {
         return new ViewStateManager();
+    }
+
+    @Provides @Singleton IntentQueryParser provideIntentQueryParser() {
+        return new IntentQueryParser();
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -149,6 +149,8 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     val routeModeCompass: CompassView by lazy { findViewById(R.id.route_mode_compass_view) as CompassView }
     val muteView: MuteView by lazy { findViewById(R.id.route_mode_mute_view) as MuteView }
 
+    var submitQueryOnMenuCreate: String? = null
+
     override public fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         app = application as EraserMapApplication
@@ -437,6 +439,11 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
         val cacheSearches = PreferenceManager.getDefaultSharedPreferences(this)
                 .getBoolean(AndroidAppSettings.KEY_CACHE_SEARCH_HISTORY, true)
         searchView?.setCacheSearchResults(cacheSearches)
+
+        if (submitQueryOnMenuCreate != null) {
+            searchView?.setQuery(submitQueryOnMenuCreate, true)
+            submitQueryOnMenuCreate = null
+        }
 
         return true
     }
@@ -1349,7 +1356,11 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     }
 
     override fun executeSearch(query: String) {
-        searchView?.setQuery(query, true)
+        if (searchView != null) {
+            searchView?.setQuery(query, true)
+        } else {
+            submitQueryOnMenuCreate = query
+        }
     }
 
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -2,6 +2,7 @@ package com.mapzen.erasermap.controller
 
 import android.location.Location
 import com.mapzen.pelias.gson.Feature
+import com.mapzen.tangram.LngLat
 import com.mapzen.valhalla.Route
 
 interface MainViewController {
@@ -29,7 +30,7 @@ interface MainViewController {
     fun startRoutingMode(feature: Feature)
     fun resumeRoutingMode(feature: Feature)
     fun shutDown()
-    fun centerMapOnLocation(location: Location, zoom: Float)
+    fun centerMapOnLocation(lngLat: LngLat, zoom: Float)
     fun setMapTilt(radians: Float)
     fun resetMute()
     fun toggleMute()
@@ -47,4 +48,5 @@ interface MainViewController {
     fun onBackPressed()
     fun stopSpeaker()
     fun checkPermissionAndEnableLocation()
+    fun executeSearch(query: String)
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/IntentQuery.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/IntentQuery.kt
@@ -1,0 +1,8 @@
+package com.mapzen.erasermap.model
+
+import com.mapzen.tangram.LngLat
+
+/**
+ * Represents components of an implicit intent query string that has been parsed.
+ */
+data class IntentQuery(val queryString: String, val focusPoint: LngLat)

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/IntentQueryParser.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/IntentQueryParser.kt
@@ -1,0 +1,37 @@
+package com.mapzen.erasermap.model
+
+import com.mapzen.tangram.LngLat
+
+/**
+ * Parses incoming query strings that may contain a name, address, and/or latitude and longitude
+ * to be displayed on the map.
+ *
+ * Some sample formats include:
+ *     * geo:0,0?q=350 5th Ave, New York, NY 10118
+ *     * http://maps.google.com/maps?q=350 5th Ave, New York, NY 10118, United States&sll=40.7484,-73.9857&radius=5
+ */
+open class IntentQueryParser {
+
+    /**
+     * Parses the query string portion of the incoming location data (everything after the "?q=").
+     */
+    open fun parse(query: String): IntentQuery? {
+        val lngLat = LngLat()
+
+        if (query.contains("sll=")) {
+            val sll = query.split("sll=")
+            if (sll.size > 1) {
+                val raw = sll[1].split("&")[0]
+                lngLat.latitude = raw.split(",")[0].toDouble()
+                lngLat.longitude = raw.split(",")[1].toDouble()
+            }
+        }
+
+        val split = query.split("q=")
+        if (split.size > 1) {
+            return IntentQuery(split[1].split("&")[0], lngLat)
+        }
+
+        return null
+    }
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/IntentQueryParser.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/IntentQueryParser.kt
@@ -29,7 +29,8 @@ open class IntentQueryParser {
 
         val split = query.split("q=")
         if (split.size > 1) {
-            return IntentQuery(split[1].split("&")[0], lngLat)
+            val encoded = split[1].split("&")[0]
+            return IntentQuery(encoded.replace("+", " "), lngLat)
         }
 
         return null

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -51,4 +51,5 @@ public interface MainPresenter {
     public fun onPlaceSearchRequested(gid: String): Boolean
     public fun onExitNavigation()
     public fun configureMapzenMap()
+    public fun onIntentQueryReceived(query: String?)
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -2,7 +2,10 @@ package com.mapzen.erasermap.presenter
 
 import android.location.Location
 import android.util.Log
+import com.mapzen.erasermap.controller.MainViewController
 import com.mapzen.erasermap.model.AppSettings
+import com.mapzen.erasermap.model.IntentQuery
+import com.mapzen.erasermap.model.IntentQueryParser
 import com.mapzen.erasermap.model.MapzenLocation
 import com.mapzen.erasermap.model.RouteManager
 import com.mapzen.erasermap.model.event.LocationChangeEvent
@@ -16,7 +19,6 @@ import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTE_PREVIEW_L
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTING
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.SEARCH
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.SEARCH_RESULTS
-import com.mapzen.erasermap.controller.MainViewController
 import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.pelias.PeliasLocationProvider
 import com.mapzen.pelias.gson.Feature
@@ -28,8 +30,9 @@ import com.squareup.otto.Bus
 import com.squareup.otto.Subscribe
 import java.util.ArrayList
 
-public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
-        val routeManager: RouteManager, val settings: AppSettings, val vsm: ViewStateManager)
+open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
+        val routeManager: RouteManager, val settings: AppSettings, val vsm: ViewStateManager,
+        val intentQueryParser: IntentQueryParser)
         : MainPresenter, RouteCallback {
 
     companion object {
@@ -346,7 +349,8 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
     override fun onFindMeButtonClick() {
         val currentLocation = mapzenLocation.getLastLocation()
         if (currentLocation is Location) {
-            mainViewController?.centerMapOnLocation(currentLocation, MainPresenter.DEFAULT_ZOOM)
+            mainViewController?.centerMapOnLocation(LngLat(currentLocation.longitude,
+                    currentLocation.latitude), MainPresenter.DEFAULT_ZOOM)
             mainViewController?.setMapTilt(0f)
             mainViewController?.setMapRotation(0f)
         }
@@ -461,9 +465,35 @@ public open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus:
         if (currentLocation is Location) {
             if (!initialized) {
                 // Show location puck and center map
-                mainViewController?.centerMapOnLocation(currentLocation, MainPresenter.DEFAULT_ZOOM)
+                mainViewController?.centerMapOnLocation(LngLat(currentLocation.longitude,
+                        currentLocation.latitude), MainPresenter.DEFAULT_ZOOM)
                 initialized = true
             }
         }
+    }
+
+    override fun onIntentQueryReceived(query: String?) {
+        if (query != null && !query.isEmpty()) {
+            val result = intentQueryParser.parse(query)
+            if (result != null) {
+                updateQueryMapPosition(result)
+                updateQuerySearchTerm(result)
+            }
+        }
+    }
+
+    private fun updateQueryMapPosition(result: IntentQuery) {
+        val focusPoint = result.focusPoint
+        if (focusPoint.latitude != 0.0 && focusPoint.longitude != 0.0) {
+            mainViewController?.centerMapOnLocation(focusPoint, MainPresenter.DEFAULT_ZOOM)
+        }
+    }
+
+    private fun updateQuerySearchTerm(result: IntentQuery) {
+        val queryString = result.queryString
+        currentSearchTerm = queryString
+        mainViewController?.hideSettingsBtn()
+        mainViewController?.hideSearchResults()
+        mainViewController?.executeSearch(queryString)
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
@@ -1,10 +1,12 @@
 package com.mapzen.erasermap.view
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
 import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
+import android.util.Log
 import android.widget.TextView
 import com.mapzen.erasermap.BuildConfig
 import com.mapzen.erasermap.CrashReportService
@@ -41,6 +43,11 @@ class InitActivity : AppCompatActivity() {
         } else {
             Handler().postDelayed({ configureKeys() }, START_DELAY_IN_MS)
         }
+
+        val data = intent.data
+        if (data != null) {
+            Log.i("Eraser Map", "Incoming implicit intent: " + Uri.decode(data.toString()))
+        }
     }
 
     private fun configureKeys() {
@@ -66,7 +73,9 @@ class InitActivity : AppCompatActivity() {
     }
 
     private fun startMainActivityAndFinish() {
-        startActivity(Intent(applicationContext, MainActivity::class.java))
+        val intent = Intent(applicationContext, MainActivity::class.java)
+        intent.data = this.intent.data
+        startActivity(intent)
         finish()
     }
 

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -2,6 +2,7 @@ package com.mapzen.erasermap;
 
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.erasermap.model.AppSettings;
+import com.mapzen.erasermap.model.IntentQueryParser;
 import com.mapzen.erasermap.model.MapzenLocation;
 import com.mapzen.erasermap.model.MapzenLocationImpl;
 import com.mapzen.erasermap.model.PermissionManager;
@@ -23,8 +24,6 @@ import com.squareup.otto.Bus;
 import org.mockito.Mockito;
 
 import android.content.Context;
-
-import java.security.Permission;
 
 import javax.inject.Singleton;
 
@@ -62,8 +61,10 @@ public class TestAndroidModule {
     }
 
     @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation, Bus bus,
-            RouteManager routeManager, AppSettings settings, ViewStateManager vsm) {
-        return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm);
+            RouteManager routeManager, AppSettings settings, ViewStateManager vsm,
+            IntentQueryParser intentQueryParser) {
+        return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm,
+                intentQueryParser);
     }
 
     @Provides @Singleton RouteManager provideRouteManager() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -3,13 +3,14 @@ package com.mapzen.erasermap.controller
 import android.graphics.PointF
 import android.location.Location
 import com.mapzen.pelias.gson.Feature
+import com.mapzen.tangram.LngLat
 import com.mapzen.valhalla.Route
 
 public class TestMainController : MainViewController {
 
     public var searchResults: List<Feature>? = null
     public var reverseGeoCodeResults: List<Feature>? = null
-    public var location: Location? = null
+    public var lngLat: LngLat? = null
     public var zoom: Float = 0f
     public var tilt: Float = 0f
     public var muted: Boolean = false
@@ -117,8 +118,8 @@ public class TestMainController : MainViewController {
         isRoutingModeVisible = true
     }
 
-    override fun centerMapOnLocation(location: Location, zoom: Float) {
-        this.location = location
+    override fun centerMapOnLocation(lngLat: LngLat, zoom: Float) {
+        this.lngLat = lngLat
         this.zoom = zoom
     }
 
@@ -197,4 +198,9 @@ public class TestMainController : MainViewController {
     override fun checkPermissionAndEnableLocation() {
 
     }
+
+    override fun executeSearch(query: String) {
+        queryText = query
+    }
+
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/IntentQueryParserTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/IntentQueryParserTest.kt
@@ -8,6 +8,7 @@ class IntentQueryParserTest {
         val TEST_QUERY = "q=350 5th Ave, New York, NY 10118"
         val TEST_QUERY_WITH_LATLNG = "q=350 5th Ave, New York, NY 10118&sll=40.7484,-73.9857"
         val TEST_QUERY_WITH_LATLNG_AND_RADIUS = "q=350 5th Ave, New York, NY 10118&sll=40.7484,-73.9857&radius=5"
+        val TEST_QUERY_DOUBLE_ENCODED = "q=Pier+97"
         val MALFORMED_QUERY = "wtf=what a terrible failure"
     }
 
@@ -40,5 +41,10 @@ class IntentQueryParserTest {
         val focusPoint = intentQueryParser.parse(TEST_QUERY_WITH_LATLNG)?.focusPoint
         assertThat(focusPoint?.latitude).isEqualTo(40.7484)
         assertThat(focusPoint?.longitude).isEqualTo(-73.9857)
+    }
+
+    @Test fun parse_shouldHandleDoubleEncodedQueryString() {
+        assertThat(intentQueryParser.parse(TEST_QUERY_DOUBLE_ENCODED)?.queryString)
+                .isEqualTo("Pier 97")
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/IntentQueryParserTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/IntentQueryParserTest.kt
@@ -1,0 +1,44 @@
+package com.mapzen.erasermap.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class IntentQueryParserTest {
+    companion object {
+        val TEST_QUERY = "q=350 5th Ave, New York, NY 10118"
+        val TEST_QUERY_WITH_LATLNG = "q=350 5th Ave, New York, NY 10118&sll=40.7484,-73.9857"
+        val TEST_QUERY_WITH_LATLNG_AND_RADIUS = "q=350 5th Ave, New York, NY 10118&sll=40.7484,-73.9857&radius=5"
+        val MALFORMED_QUERY = "wtf=what a terrible failure"
+    }
+
+    val intentQueryParser = IntentQueryParser()
+
+    @Test fun shouldNotBeNull() {
+        assertThat(intentQueryParser).isNotNull()
+    }
+
+    @Test fun parse_shouldParseQueryString() {
+        assertThat(intentQueryParser.parse(TEST_QUERY)?.queryString)
+                .isEqualTo("350 5th Ave, New York, NY 10118")
+    }
+
+    @Test fun parse_shouldParseQueryStringWithFocusPoint() {
+        assertThat(intentQueryParser.parse(TEST_QUERY_WITH_LATLNG)?.queryString)
+                .isEqualTo("350 5th Ave, New York, NY 10118")
+    }
+
+    @Test fun parse_shouldParseQueryStringWithFocusPointAndRadius() {
+        assertThat(intentQueryParser.parse(TEST_QUERY_WITH_LATLNG_AND_RADIUS)?.queryString)
+                .isEqualTo("350 5th Ave, New York, NY 10118")
+    }
+
+    @Test fun parse_shouldReturnNullForMalformedQuery() {
+        assertThat(intentQueryParser.parse(MALFORMED_QUERY)).isNull()
+    }
+
+    @Test fun parse_shouldParseFocusPoint() {
+        val focusPoint = intentQueryParser.parse(TEST_QUERY_WITH_LATLNG)?.focusPoint
+        assertThat(focusPoint?.latitude).isEqualTo(40.7484)
+        assertThat(focusPoint?.longitude).isEqualTo(-73.9857)
+    }
+}


### PR DESCRIPTION
Handle implicit geo and map intents generated by other applications.

* Updates AndroidManifest.xml to receive geo and maps intents
* Log incoming intent and forward to MainActivity
* Perform input validation and pass valid query to parser
* Adds logic to parse query string
* Populate current search term with IntentQueryParser result
* Execute search on incoming query string
* Set map position prior to search based on focus point if available
* Handle implicit intent even if app is already running in background

Closes #545 