### PR TITLE
Hide settings button on rotate search results

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -865,7 +865,8 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     }
 
     override fun hideSettingsBtn() {
-        optionsMenu?.findItem(R.id.action_settings)?.setVisible(false)
+        Handler().postDelayed( { optionsMenu?.findItem(R.id.action_settings)?.isVisible = false },
+                100)
     }
 
     override fun showSettingsBtn() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -139,6 +139,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     }
 
     private fun onRestoreViewStateSearchResults() {
+        mainViewController?.hideSettingsBtn()
         if (searchResults?.features != null) {
             if (!reverseGeo) {
                 mainViewController?.showSearchResults(searchResults?.features)

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -111,6 +111,15 @@ class MainPresenterTest {
         assertThat(newController.searchResults).isEqualTo(features)
     }
 
+    @Test fun onRestoreViewState_shouldHideSettingsButtonWhileShowingSearchResults() {
+        val result = Result()
+        result.features = ArrayList<Feature>()
+        presenter.onSearchResultsAvailable(result)
+        mainController.isSettingsVisible = true
+        presenter.onRestoreViewState()
+        assertThat(mainController.isSettingsVisible).isFalse()
+    }
+
     @Test fun onRestoreViewState_shouldRestoreRoutePreview() {
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
         val newController = TestMainController()


### PR DESCRIPTION
When viewing search results the settings button should remain hidden during device rotation. Posts a delayed runnable to ensure options menu has been created before attempting to hide.

Closes #588 