### PR TITLE
Stop location services when app in bg and not routing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,7 +128,7 @@ gradle.startParameter.getTaskNames().each { task ->
 dependencies {
   compile 'com.android.support:appcompat-v7:23.4.0'
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  compile 'com.mapzen:mapzen-android-sdk:1.0.3'
+  compile 'com.mapzen:mapzen-android-sdk:1.0.4-SNAPSHOT'
   compile('com.mapzen.android:pelias-android-sdk:0.7.1-SNAPSHOT') {
     exclude group: 'javax.annotation:javax', module: 'javax.annotation-api'
   }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -229,9 +229,9 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
 
     override public fun onPause() {
         super.onPause()
-        presenter.onPause()
         app?.onActivityPause()
-        if (mapzenMap?.isMyLocationEnabled != null && mapzenMap?.isMyLocationEnabled as Boolean) {
+        if (mapzenMap?.isMyLocationEnabled != null && mapzenMap?.isMyLocationEnabled as Boolean
+                && !presenter.routingEnabled) {
             enableLocation = true
             mapzenMap?.isMyLocationEnabled = false
         }
@@ -1254,9 +1254,9 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     }
 
     override fun hideRoutingMode() {
+        presenter.routingEnabled = false
         setDefaultCamera()
         checkPermissionAndEnableLocation()
-        presenter.routingEnabled = false
         routeModeView.visibility = View.GONE
         val location = routeManager.origin
         val feature = routeManager.destination

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -118,6 +118,7 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     var voiceNavigationController: VoiceNavigationController? = null
     var notificationCreator: NotificationCreator? = null
     lateinit var confidenceHandler: ConfidenceHandler
+    var enableLocation: Boolean = false
 
     // activity_main
     val mapView: MapView by lazy { findViewById(R.id.map) as MapView }
@@ -219,12 +220,21 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
         autoCompleteAdapter?.clear()
         autoCompleteAdapter?.notifyDataSetChanged()
         invalidateOptionsMenu()
+
+        if (enableLocation) {
+            enableLocation = false
+            checkPermissionAndEnableLocation()
+        }
     }
 
     override public fun onPause() {
         super.onPause()
         presenter.onPause()
         app?.onActivityPause()
+        if (mapzenMap?.isMyLocationEnabled != null && mapzenMap?.isMyLocationEnabled as Boolean) {
+            enableLocation = true
+            mapzenMap?.isMyLocationEnabled = false
+        }
     }
 
     override public fun onStop() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -40,7 +40,6 @@ public interface MainPresenter {
     public fun onBackPressed()
     public fun onRestoreViewState()
     public fun onResume()
-    public fun onPause()
     public fun onFindMeButtonClick()
     public fun onMuteClick()
     public fun onCompassClick()

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -295,6 +295,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     private fun onBackPressedStateRouting() {
         vsm.viewState = ViewStateManager.ViewState.ROUTE_PREVIEW
         routingEnabled = false
+        mapzenLocation.stopLocationUpdates() //must call before calling mainViewController?.hideRoutingMode()
         mainViewController?.hideRoutingMode()
         mainViewController?.stopSpeaker()
     }
@@ -315,28 +316,18 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
         generateRoutingMode()
         vsm.viewState = ViewStateManager.ViewState.ROUTING
         routeViewController?.hideResumeButton()
+        mapzenLocation.startLocationUpdates()
     }
 
     @Subscribe public fun onLocationChangeEvent(event: LocationChangeEvent) {
         if (routingEnabled) {
             routeViewController?.onLocationChanged(event.location)
         }
-        //TODO
-//        else {
-//            mainViewController?.showCurrentLocation(event.location)
-//        }
     }
 
     override fun onResume() {
         if (!isRouting() && !isRoutingDirectionList()) {
-            mapzenLocation.startLocationUpdates()
             mainViewController?.checkPermissionAndEnableLocation()
-        }
-    }
-
-    override fun onPause() {
-        if (!isRouting() && !isRoutingDirectionList()) {
-            mapzenLocation.stopLocationUpdates()
         }
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -324,28 +324,29 @@ class MainPresenterTest {
         assertThat(mainController.isCenteredOnTappedFeature).isTrue()
     }
 
-    @Test fun onPause_shouldDisconnectLocationUpdates() {
-        presenter.onPause()
+    @Test fun onBackPressed_shouldDisconnectLocationUpdates() {
+        presenter.vsm.viewState = ROUTING
+        presenter.onBackPressed()
         assertThat(mapzenLocation.connected).isFalse()
     }
 
-    @Test fun onPause_shouldNotDisconnectLocationUpdatesWhileRouting() {
+    @Test fun onResume_shouldNotDisconnectLocationUpdates() {
         mapzenLocation.connected = true
         presenter.onClickStartNavigation()
-        presenter.onPause()
-        assertThat(mapzenLocation.connected).isTrue()
-    }
-
-    @Test fun onResume_shouldReconnectLocationClientAndInitLocationUpdates() {
-        mapzenLocation.connected = false
-        vsm.viewState = DEFAULT
         presenter.onResume()
         assertThat(mapzenLocation.connected).isTrue()
     }
 
-    @Test fun onResume_shouldNotReconnectClientAndInitUpdatesWhileRouting() {
+    @Test fun onClickStartNavigation_shouldReconnectLocationClientAndInitLocationUpdates() {
         mapzenLocation.connected = false
+        vsm.viewState = DEFAULT
         presenter.onClickStartNavigation()
+        assertThat(mapzenLocation.connected).isTrue()
+    }
+
+    @Test fun onResume_shouldNotReconnectClientAndInitUpdatesWhileRouting() {
+        presenter.onClickStartNavigation()
+        mapzenLocation.connected = false
         presenter.onResume()
         assertThat(mapzenLocation.connected).isFalse()
     }


### PR DESCRIPTION
- Moves start/stop of `MapzenLocation` to correspond with start/stop routing mode
- Sets `MapzenMap#isMyLocationEnabled` to be `false` when app exits
- Updates mapzen-android-sdk to 1.0.4-SNAPSHOT which uses a version of LOST that has better handling for multiple `FusedLocationProviderApiImpl` objects