### PR TITLE
Move ApiKey configuration into init block

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -146,6 +146,9 @@ dependencies {
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.9.5'
+  testCompile 'org.powermock:powermock:1.6.4'
+  testCompile 'org.powermock:powermock-module-junit4:1.6.4'
+  testCompile 'org.powermock:powermock-api-mockito:1.6.4'
   testCompile 'org.assertj:assertj-core:1.7.0'
   testCompile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
   testCompile 'org.json:json:20160212'

--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -2,6 +2,7 @@ package com.mapzen.erasermap;
 
 import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.erasermap.model.AndroidAppSettings;
+import com.mapzen.erasermap.model.ApiKeys;
 import com.mapzen.erasermap.model.AppSettings;
 import com.mapzen.erasermap.model.IntentQueryParser;
 import com.mapzen.erasermap.model.MapzenLocation;
@@ -65,16 +66,16 @@ public class AndroidModule {
                 intentQueryParser);
     }
 
-    @Provides @Singleton RouteManager provideRouteManager(AppSettings settings) {
+    @Provides @Singleton RouteManager provideRouteManager(AppSettings settings, ApiKeys apiKeys) {
         final ValhallaRouteManager manager = new ValhallaRouteManager(settings,
                 new ValhallaRouterFactory());
-        manager.setApiKey(application.getApiKeys().getRoutingKey());
+        manager.setApiKey(apiKeys.getRoutingKey());
         return manager;
     }
 
-    @Provides @Singleton TileHttpHandler provideTileHttpHandler() {
+    @Provides @Singleton TileHttpHandler provideTileHttpHandler(ApiKeys apiKeys) {
         final TileHttpHandler handler = new TileHttpHandler(application);
-        handler.setApiKey(application.getApiKeys().getTilesKey());
+        handler.setApiKey(apiKeys.getTilesKey());
         return handler;
     }
 
@@ -101,4 +102,9 @@ public class AndroidModule {
     @Provides @Singleton PermissionManager providePermissionManager() {
         return new PermissionManager();
     }
+
+    @Provides @Singleton ApiKeys provideApiKeys() {
+        return new ApiKeys(application);
+    }
+
 }

--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -104,7 +104,7 @@ public class AndroidModule {
     }
 
     @Provides @Singleton ApiKeys provideApiKeys() {
-        return new ApiKeys(application);
+        return ApiKeys.Companion.sharedInstance(application);
     }
 
 }

--- a/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
+++ b/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
@@ -39,7 +39,6 @@ public class EraserMapApplication extends Application {
 
     private ApplicationComponent component;
     private boolean isVisible = true;
-    private ApiKeys apiKeys;
 
     @Override
     public void onCreate() {
@@ -65,11 +64,4 @@ public class EraserMapApplication extends Application {
         return component;
     }
 
-    public @Nullable ApiKeys getApiKeys() {
-        return apiKeys;
-    }
-
-    public void setApiKeys(@NotNull ApiKeys apiKeys) {
-        this.apiKeys = apiKeys;
-    }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -103,6 +103,7 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     @Inject lateinit var pelias: Pelias
     @Inject lateinit var speaker: Speaker
     @Inject lateinit var permissionManager: PermissionManager
+    @Inject lateinit var apiKeys: ApiKeys
 
     lateinit var app: EraserMapApplication
     var mapzenMap : MapzenMap? = null
@@ -237,9 +238,7 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
     }
 
     private fun initMapzenMap() {
-        val application = application as EraserMapApplication
-        val keys = application.apiKeys as ApiKeys
-        mapView.getMapAsync(keys.tilesKey, {
+        mapView.getMapAsync(apiKeys.tilesKey, {
             this.mapzenMap = it
             configureMapzenMap()
             presenter.configureMapzenMap()
@@ -385,7 +384,7 @@ class MainActivity : AppCompatActivity(), MainViewController, RouteCallback,
         val listView = findViewById(R.id.auto_complete) as AutoCompleteListView
         val emptyView = findViewById(android.R.id.empty) as View
         val locationProvider = presenter.getPeliasLocationProvider()
-        val apiKeys = app.apiKeys
+        val apiKeys = apiKeys
         val callback = PeliasCallback()
 
         addSearchViewToActionBar(searchView)

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
@@ -6,11 +6,22 @@ import com.mapzen.erasermap.EraserMapApplication
 /**
  * Wrangle API keys for Mapzen services
  */
-data class ApiKeys(val application: EraserMapApplication) {
+class ApiKeys private constructor(val application: EraserMapApplication) {
 
     lateinit var tilesKey: String
     lateinit var searchKey: String
     lateinit var routingKey: String
+
+    companion object {
+        var instance: ApiKeys? = null
+
+        fun sharedInstance(application: EraserMapApplication): ApiKeys {
+            if (instance == null) {
+                instance = ApiKeys(application)
+            }
+            return instance as ApiKeys
+        }
+    }
 
     init {
         configureKeys()

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
@@ -1,16 +1,34 @@
 package com.mapzen.erasermap.model
 
+import com.mapzen.erasermap.BuildConfig
+import com.mapzen.erasermap.EraserMapApplication
+
 /**
  * Wrangle API keys for Mapzen services
  */
-data class ApiKeys(
-        val tilesKey: String,
-        val searchKey: String,
-        val routingKey: String) {
+data class ApiKeys(val application: EraserMapApplication) {
+
+    lateinit var tilesKey: String
+    lateinit var searchKey: String
+    lateinit var routingKey: String
 
     init {
+        configureKeys()
         if (tilesKey.isEmpty()) throw IllegalArgumentException("Tiles key cannot be empty.")
         if (searchKey.isEmpty()) throw IllegalArgumentException("Search key cannot be empty.")
         if (routingKey.isEmpty()) throw IllegalArgumentException("Routing key cannot be empty.")
+    }
+
+    private fun configureKeys() {
+        if (BuildConfig.DEBUG) {
+            tilesKey = BuildConfig.VECTOR_TILE_API_KEY
+            searchKey = BuildConfig.PELIAS_API_KEY
+            routingKey = BuildConfig.VALHALLA_API_KEY
+        } else {
+            val crypt = SimpleCrypt(application)
+            tilesKey = crypt.decode(BuildConfig.VECTOR_TILE_API_KEY)
+            searchKey = crypt.decode(BuildConfig.PELIAS_API_KEY)
+            routingKey = crypt.decode(BuildConfig.VALHALLA_API_KEY)
+        }
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
@@ -38,37 +38,11 @@ class InitActivity : AppCompatActivity() {
             (findViewById(R.id.build_number) as TextView).text = BuildConfig.BUILD_NUMBER
         }
 
-        if (app.apiKeys != null) {
-            startMainActivityAndFinish()
-        } else {
-            Handler().postDelayed({ configureKeys() }, START_DELAY_IN_MS)
-        }
+        Handler().postDelayed({ startMainActivityAndFinish() }, START_DELAY_IN_MS)
 
         val data = intent.data
         if (data != null) {
             Log.i("Eraser Map", "Incoming implicit intent: " + Uri.decode(data.toString()))
-        }
-    }
-
-    private fun configureKeys() {
-        if (BuildConfig.VECTOR_TILE_API_KEY == null ||
-                BuildConfig.PELIAS_API_KEY == null ||
-                BuildConfig.VALHALLA_API_KEY == null) {
-            showApiKeyDialog()
-        } else {
-            if (BuildConfig.DEBUG) {
-                val tilesKey = BuildConfig.VECTOR_TILE_API_KEY
-                val searchKey = BuildConfig.PELIAS_API_KEY
-                val routingKey = BuildConfig.VALHALLA_API_KEY
-                app.setApiKeys(ApiKeys(tilesKey, searchKey, routingKey))
-            } else {
-                val crypt = SimpleCrypt(application)
-                val tilesKey = crypt.decode(BuildConfig.VECTOR_TILE_API_KEY)
-                val searchKey = crypt.decode(BuildConfig.PELIAS_API_KEY)
-                val routingKey = crypt.decode(BuildConfig.VALHALLA_API_KEY)
-                app.setApiKeys(ApiKeys(tilesKey, searchKey, routingKey))
-            }
-            startMainActivityAndFinish()
         }
     }
 
@@ -81,24 +55,5 @@ class InitActivity : AppCompatActivity() {
 
     private fun initCrashReportService() {
         crashReportService.initAndStartSession(this)
-    }
-
-    private fun showApiKeyDialog() {
-        var message = "The following API keys are not set: "
-        if (BuildConfig.VECTOR_TILE_API_KEY == null) {
-            message += "\n* VECTOR TILE"
-        }
-        if (BuildConfig.PELIAS_API_KEY == null) {
-            message += "\n* PELIAS"
-        }
-        if (BuildConfig.VALHALLA_API_KEY == null) {
-            message += "\n* VALHALLA"
-        }
-
-        AlertDialog.Builder(this)
-                .setMessage(message)
-                .setCancelable(false)
-                .setPositiveButton("Exit Application", { dialogInterface, i -> finish() })
-                .show()
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/InitActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.os.Handler
-import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.util.Log
 import android.widget.TextView
@@ -13,8 +12,6 @@ import com.mapzen.erasermap.CrashReportService
 import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
 import com.mapzen.erasermap.controller.MainActivity
-import com.mapzen.erasermap.model.ApiKeys
-import com.mapzen.erasermap.model.SimpleCrypt
 import javax.inject.Inject
 
 class InitActivity : AppCompatActivity() {

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -99,6 +99,6 @@ public class TestAndroidModule {
     }
 
     @Provides @Singleton ApiKeys provideApiKeys() {
-        return new ApiKeys(application);
+        return ApiKeys.Companion.sharedInstance(application);
     }
 }

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap;
 
 import com.mapzen.android.lost.api.LostApiClient;
+import com.mapzen.erasermap.model.ApiKeys;
 import com.mapzen.erasermap.model.AppSettings;
 import com.mapzen.erasermap.model.IntentQueryParser;
 import com.mapzen.erasermap.model.MapzenLocation;
@@ -95,5 +96,9 @@ public class TestAndroidModule {
 
     @Provides @Singleton PermissionManager providePermissionManager() {
         return new PermissionManager();
+    }
+
+    @Provides @Singleton ApiKeys provideApiKeys() {
+        return new ApiKeys(application);
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
@@ -10,7 +10,7 @@ import org.powermock.api.mockito.PowerMockito
 
 class ApiKeysTest {
     val application = EraserMapApplication()
-    val apiKeys = ApiKeys(application)
+    val apiKeys = ApiKeys.Companion.sharedInstance(application)
 
     @Test fun shouldNotBeNull() {
         assertThat(apiKeys).isNotNull()
@@ -19,18 +19,18 @@ class ApiKeysTest {
     @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptyTilesKey() {
         PowerMockito.mockStatic(BuildConfig::class.java)
         Mockito.doReturn(null).`when`(BuildConfig.VECTOR_TILE_API_KEY)
-        ApiKeys(application)
+        ApiKeys.Companion.sharedInstance(application)
     }
 
     @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptySearchKey() {
         PowerMockito.mockStatic(BuildConfig::class.java)
         Mockito.doReturn(null).`when`(BuildConfig.PELIAS_API_KEY)
-        ApiKeys(application)
+        ApiKeys.Companion.sharedInstance(application)
     }
 
     @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptyRoutingKey() {
         PowerMockito.mockStatic(BuildConfig::class.java)
         Mockito.doReturn(null).`when`(BuildConfig.VALHALLA_API_KEY)
-        ApiKeys(application)
+        ApiKeys.Companion.sharedInstance(application)
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
@@ -1,24 +1,36 @@
 package com.mapzen.erasermap.model
 
+import com.mapzen.erasermap.BuildConfig
+import com.mapzen.erasermap.EraserMapApplication
 import org.assertj.core.api.Assertions.assertThat
+
 import org.junit.Test
+import org.mockito.Mockito
+import org.powermock.api.mockito.PowerMockito
 
 class ApiKeysTest {
-    val apiKeys = ApiKeys("vector-tiles-test", "search-test", "valhalla-test")
+    val application = EraserMapApplication()
+    val apiKeys = ApiKeys(application)
 
     @Test fun shouldNotBeNull() {
         assertThat(apiKeys).isNotNull()
     }
 
     @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptyTilesKey() {
-        ApiKeys("", "search-test", "valhalla-test")
+        PowerMockito.mockStatic(BuildConfig::class.java)
+        Mockito.doReturn(null).`when`(BuildConfig.VECTOR_TILE_API_KEY)
+        ApiKeys(application)
     }
 
     @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptySearchKey() {
-        ApiKeys("vector-tiles-test", "", "valhalla-test")
+        PowerMockito.mockStatic(BuildConfig::class.java)
+        Mockito.doReturn(null).`when`(BuildConfig.PELIAS_API_KEY)
+        ApiKeys(application)
     }
 
     @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptyRoutingKey() {
-        ApiKeys("vector-tiles-test", "search-test", "")
+        PowerMockito.mockStatic(BuildConfig::class.java)
+        Mockito.doReturn(null).`when`(BuildConfig.VALHALLA_API_KEY)
+        ApiKeys(application)
     }
 }


### PR DESCRIPTION
- `MainActivity` will initialize the keys when it is created
- Initialization will happen once per application lifecycle