### PR TITLE
Fix search results animation loop; refactor search

### DIFF
--- a/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
+++ b/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
@@ -7,6 +7,7 @@ import com.mapzen.erasermap.view.DistanceView;
 import com.mapzen.erasermap.view.InitActivity;
 import com.mapzen.erasermap.view.RouteModeView;
 import com.mapzen.erasermap.view.SearchResultsAdapter;
+import com.mapzen.erasermap.view.SearchResultsView;
 import com.mapzen.erasermap.view.SettingsActivity;
 import com.mapzen.erasermap.view.ViewAboutPreference;
 import com.mapzen.erasermap.view.VoiceNavigationController;
@@ -33,6 +34,7 @@ public class EraserMapApplication extends Application {
         void inject(VoiceNavigationController controller);
         void inject(MockLocationReceiver receiver);
         void inject(ViewAboutPreference viewAboutPreference);
+        void inject(SearchResultsView searchResultsView);
     }
 
     private ApplicationComponent component;

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -49,4 +49,5 @@ interface MainViewController {
     fun stopSpeaker()
     fun checkPermissionAndEnableLocation()
     fun executeSearch(query: String)
+    fun onCloseAllSearchResults()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/SearchViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/SearchViewController.kt
@@ -1,0 +1,37 @@
+package com.mapzen.erasermap.controller
+
+import android.view.View
+import com.mapzen.erasermap.model.ApiKeys
+import com.mapzen.erasermap.presenter.MainPresenter
+import com.mapzen.erasermap.view.SearchResultsAdapter
+import com.mapzen.pelias.PeliasLocationProvider
+import com.mapzen.pelias.widget.AutoCompleteListView
+import com.mapzen.pelias.widget.PeliasSearchView
+
+interface SearchViewController {
+    var mainController: MainViewController?
+    var searchView: PeliasSearchView?
+    var autoCompleteListView: AutoCompleteListView?
+    var onSearchResultsSelectedListener: OnSearchResultSelectedListener?
+
+    fun initSearchView(searchView: PeliasSearchView,
+            autoCompleteListView: AutoCompleteListView,
+            emptyView: View,
+            presenter: MainPresenter,
+            locationProvider: PeliasLocationProvider,
+            apiKeys: ApiKeys?,
+            callback: MainActivity.PeliasCallback)
+    fun setSearchResultsAdapter(adapter: SearchResultsAdapter)
+    fun showSearchResults()
+    fun hideSearchResults()
+    fun isSearchResultsVisible(): Int
+    fun setCurrentItem(position: Int)
+    fun getCurrentItem(): Int
+
+    interface OnSearchResultSelectedListener {
+        fun onSearchResultSelected(position: Int)
+    }
+
+    open fun enableSearch()
+    open fun disableSearch()
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -53,7 +53,6 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     private var initialized = false
     private var restoreReverseGeoOnBack = false
 
-
     /**
      * We will migrate to Retrofit2 where we will have ability to cancel requests. Before then,
      * we want to ignore all {@link RouteManager#fetchRoute} requests until we receive a
@@ -169,7 +168,9 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     }
 
     override fun onExpandSearchView() {
-        vsm.viewState = ViewStateManager.ViewState.SEARCH
+        if (vsm.viewState != ViewStateManager.ViewState.SEARCH_RESULTS) {
+            vsm.viewState = ViewStateManager.ViewState.SEARCH
+        }
         mainViewController?.hideSettingsBtn()
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsView.kt
@@ -1,49 +1,163 @@
 package com.mapzen.erasermap.view
 
 import android.content.Context
-import android.support.v4.view.PagerAdapter
+import android.preference.PreferenceManager
 import android.support.v4.view.ViewPager
+import android.text.InputType
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
+import com.mapzen.erasermap.controller.MainActivity
+import com.mapzen.erasermap.controller.MainViewController
+import com.mapzen.erasermap.controller.SearchViewController
+import com.mapzen.erasermap.model.AndroidAppSettings
+import com.mapzen.erasermap.model.ApiKeys
+import com.mapzen.erasermap.presenter.MainPresenter
+import com.mapzen.pelias.Pelias
+import com.mapzen.pelias.PeliasLocationProvider
+import com.mapzen.pelias.SavedSearch
+import com.mapzen.pelias.widget.AutoCompleteListView
+import com.mapzen.pelias.widget.PeliasSearchView
+import javax.inject.Inject
 
-public class SearchResultsView(context: Context, attrs: AttributeSet)
-        : LinearLayout(context, attrs), ViewPager.OnPageChangeListener {
+open class SearchResultsView(context: Context, attrs: AttributeSet)
+        : LinearLayout(context, attrs), ViewPager.OnPageChangeListener, SearchViewController {
 
-    public var onSearchResultsSelectedListener: OnSearchResultSelectedListener? = null
+    override var mainController: MainViewController? = null
+    override var searchView: PeliasSearchView? = null
+    override var autoCompleteListView: AutoCompleteListView? = null
+    override var onSearchResultsSelectedListener:
+            SearchViewController.OnSearchResultSelectedListener? = null
+
+    @Inject lateinit var pelias: Pelias
+    @Inject lateinit var savedSearch: SavedSearch
 
     init {
         val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
         inflater.inflate(R.layout.view_search_results, this, true)
-        setOrientation(LinearLayout.VERTICAL)
+        orientation = LinearLayout.VERTICAL
+        (context.applicationContext as EraserMapApplication).component().inject(this)
     }
 
-    public fun setAdapter(adapter: PagerAdapter) {
-        val pager = findViewById(R.id.pager) as ViewPager
-        val indicator = findViewById(R.id.indicator) as TextView
-        pager.setAdapter(adapter)
-        pager.setOnPageChangeListener(this)
-        indicator.setText(getResources().getString(R.string.search_results_indicator,
-                pager.getCurrentItem() + 1, pager.getAdapter().getCount()))
+    override fun initSearchView(searchView: PeliasSearchView,
+            autoCompleteListView: AutoCompleteListView,
+            emptyView: View,
+            presenter: MainPresenter,
+            locationProvider: PeliasLocationProvider,
+            apiKeys: ApiKeys?,
+            callback: MainActivity.PeliasCallback) {
 
-        if (adapter.getCount() > 1) {
-            indicator.setVisibility(View.VISIBLE)
-        } else {
-            indicator.setVisibility(View.GONE)
+        this.searchView = searchView
+        this.autoCompleteListView = autoCompleteListView
+        autoCompleteListView.hideHeader()
+
+        searchView.setRecentSearchIconResourceId(R.drawable.ic_recent)
+        searchView.setAutoCompleteIconResourceId(R.drawable.ic_pin_c)
+        initAutoCompleteAdapter()
+        autoCompleteListView.adapter = initAutoCompleteAdapter()
+        pelias.setLocationProvider(locationProvider)
+        pelias.setApiKey(apiKeys?.searchKey)
+        searchView.setAutoCompleteListView(autoCompleteListView)
+        searchView.setSavedSearch(savedSearch)
+        searchView.setPelias(pelias)
+        searchView.setCallback(callback)
+        searchView.setOnSubmitListener({
+            presenter.reverseGeoLngLat = null
+            presenter.currentSearchTerm = searchView.query.toString()
+            presenter.onQuerySubmit()
+        })
+        searchView.setIconifiedByDefault(false)
+        searchView.imeOptions += EditorInfo.IME_FLAG_NO_EXTRACT_UI
+        searchView.queryHint = context.getString(R.string.search_hint)
+        autoCompleteListView.emptyView = emptyView
+        restoreCurrentSearchTerm(presenter)
+        searchView.setOnPeliasFocusChangeListener { view, b ->
+            if (b) {
+                mainController?.expandSearchView()
+            } else if (presenter.resultListVisible) {
+                mainController?.onCloseAllSearchResults()
+                enableSearch()
+            } else {
+                searchView.setQuery(presenter.currentSearchTerm, false)
+            }
+        }
+        searchView.setOnBackPressListener { mainController?.collapseSearchView() }
+        val cacheSearches = PreferenceManager.getDefaultSharedPreferences(context)
+                .getBoolean(AndroidAppSettings.KEY_CACHE_SEARCH_HISTORY, true)
+        searchView.setCacheSearchResults(cacheSearches)
+    }
+
+    private fun initAutoCompleteAdapter(): SearchListViewAdapter =
+            SearchListViewAdapter(context, R.layout.list_item_auto_complete,
+                searchView as PeliasSearchView, savedSearch)
+
+    private fun restoreCurrentSearchTerm(presenter: MainPresenter) {
+        val term = presenter.currentSearchTerm
+        if (term != null) {
+            searchView?.setQuery(term, false)
+            if (visibility == View.VISIBLE
+                    && presenter.reverseGeo == false) {
+                searchView?.clearFocus()
+                mainController?.showActionViewAll()
+            } else {
+                mainController?.hideActionViewAll()
+            }
+            presenter.currentSearchTerm = null
         }
     }
 
-    public fun setCurrentItem(position: Int) {
+    override fun setSearchResultsAdapter(adapter: SearchResultsAdapter) {
         val pager = findViewById(R.id.pager) as ViewPager
-        pager.setCurrentItem(position)
+        val indicator = findViewById(R.id.indicator) as TextView
+        pager.adapter = adapter
+        pager.addOnPageChangeListener(this)
+        indicator.text = resources.getString(R.string.search_results_indicator,
+                pager.currentItem + 1, pager.adapter.count)
+        setIndicatorVisibility(adapter, indicator)
     }
 
-    public fun getCurrentItem(): Int {
-        val pager = findViewById(R.id.pager) as ViewPager
-        return pager.getCurrentItem()
+    private fun setIndicatorVisibility(adapter: SearchResultsAdapter, indicator: TextView) {
+        if (adapter.count > 1) {
+            indicator.visibility = VISIBLE
+        } else {
+            indicator.visibility = GONE
+        }
+    }
+
+    override fun setCurrentItem(position: Int) {
+        (findViewById(R.id.pager) as ViewPager).currentItem = position
+    }
+
+    override fun getCurrentItem(): Int = (findViewById(R.id.pager) as ViewPager).currentItem
+
+    override fun showSearchResults() {
+        visibility = VISIBLE
+    }
+
+    override fun hideSearchResults() {
+        visibility = GONE
+    }
+
+    override fun isSearchResultsVisible(): Int {
+        return visibility
+    }
+
+    override fun enableSearch() {
+        searchView?.inputType = InputType.TYPE_CLASS_TEXT
+        val closeButton = searchView?.findViewById(R.id.search_close_btn) as ImageView
+        closeButton.visibility = View.VISIBLE
+    }
+
+    override fun disableSearch() {
+        searchView?.inputType = InputType.TYPE_NULL
+        val closeButton = searchView?.findViewById(R.id.search_close_btn) as ImageView
+        closeButton.visibility = View.GONE
     }
 
     override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
@@ -52,16 +166,12 @@ public class SearchResultsView(context: Context, attrs: AttributeSet)
     override fun onPageSelected(position: Int) {
         val pager = findViewById(R.id.pager) as ViewPager
         val indicator = findViewById(R.id.indicator) as TextView
-        indicator.setText(getResources().getString(R.string.search_results_indicator,
-                position + 1, pager.getAdapter().getCount()))
+        indicator.text = resources.getString(R.string.search_results_indicator,
+                position + 1, pager.adapter.count)
 
         onSearchResultsSelectedListener?.onSearchResultSelected(position)
     }
 
     override fun onPageScrollStateChanged(state: Int) {
-    }
-
-    public interface OnSearchResultSelectedListener {
-        public fun onSearchResultSelected(position: Int)
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,6 @@
     <string name="cache_search_results_status">Cache Search Results %s</string>
     <string name="rerouting">Rerouting</string>
 
-    <string name="need_permissions">Turn on location permissions in your system settings
-        menu</string>
+    <string name="need_permissions">Turn on location permissions in your system settings menu</string>
+    <string name="search_hint">Search for place or address</string>
 </resources>

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -7,6 +7,9 @@ import com.mapzen.tangram.LngLat
 import com.mapzen.valhalla.Route
 
 public class TestMainController : MainViewController {
+    override fun onCloseAllSearchResults() {
+        throw UnsupportedOperationException()
+    }
 
     public var searchResults: List<Feature>? = null
     public var reverseGeoCodeResults: List<Feature>? = null

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -17,6 +17,7 @@ import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.DEFAULT
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTE_DIRECTION_LIST
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTE_PREVIEW
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTING
+import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.SEARCH
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.SEARCH_RESULTS
 import com.mapzen.erasermap.view.TestRouteController
 import com.mapzen.pelias.gson.Feature
@@ -211,6 +212,18 @@ class MainPresenterTest {
         mainController.isSettingsVisible = false
         presenter.onCollapseSearchView()
         assertThat(mainController.isSettingsVisible).isFalse()
+    }
+
+    @Test fun onExpandSearchView_shouldSetViewState() {
+        vsm.viewState = DEFAULT
+        presenter.onExpandSearchView()
+        assertThat(vsm.viewState).isEqualTo(SEARCH)
+    }
+
+    @Test fun onExpandSearchView_shouldNotSetViewStateIfAlreadyViewingResults() {
+        vsm.viewState = SEARCH_RESULTS
+        presenter.onExpandSearchView()
+        assertThat(vsm.viewState).isEqualTo(SEARCH_RESULTS)
     }
 
     @Test fun onExpandSearchView_shouldHideActionSettings() {


### PR DESCRIPTION
Summary of changes:
* Extract `SearchViewController` interface
* Make `SearchResultsView` compound view implement `SearchViewController` interface
* Makes `searchView` a member of search controller
* Moves `searchView` initialization into `SearchResultsView`
* Fixes auto complete empty view (no recent searches)
* Moves search hint from hardcoded literal to strings.xml
* Fixes full search result list view
* Fixes issue where opening search results list view would cause results to clear on device rotation
* Prevents infinite animation loop by setting view pager position immediately but posting map operations in a delayed runnable (to wait until map is initialized).
* Random Kotlin cleanup

Possible future enhancements:
* Introduce `SearchPresenter` class to maintain search state and handle user interactions separate from `MainPresenter`
* Move all search API calls into `SearchPresenter` and/or new model classes managed by it.
* Move additional search view logic from `MainActivity` into `SearchResultsView`

Closes #589