### PR TITLE
Migrate to MapzenRouter API

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -140,6 +140,7 @@ dependencies {
   compile 'com.splunk.mint:mint:4.2.1'
   compile 'com.squareup.okhttp:okhttp:2.4.0'
   compile 'com.mapzen.android:speakerbox:1.4.1-SNAPSHOT'
+  compile 'com.mapzen:on-the-road:0.8.2-SNAPSHOT'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.9.5'

--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -69,7 +69,7 @@ public class AndroidModule {
 
     @Provides @Singleton RouteManager provideRouteManager(AppSettings settings, ApiKeys apiKeys) {
         final ValhallaRouteManager manager = new ValhallaRouteManager(settings,
-                new ValhallaRouterFactory());
+                new ValhallaRouterFactory(), application.getApplicationContext());
         manager.setApiKey(apiKeys.getRoutingKey());
         return manager;
     }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/AndroidAppSettings.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/AndroidAppSettings.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.location.Location
 import android.preference.PreferenceManager
 import com.mapzen.android.MapzenMap
+import com.mapzen.android.MapzenRouter
 import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
 import com.mapzen.pelias.SavedSearch
@@ -38,15 +39,15 @@ class AndroidAppSettings(val application: EraserMapApplication) : AppSettings {
     /**
      * Routing distance units setting.
      */
-    override var distanceUnits: Router.DistanceUnits
+    override var distanceUnits: MapzenRouter.DistanceUnits
         get() {
             val value = prefs.getString(KEY_DISTANCE_UNITS, null)
             when (value) {
-                Router.DistanceUnits.MILES.toString() -> return Router.DistanceUnits.MILES
-                Router.DistanceUnits.KILOMETERS.toString() -> return Router.DistanceUnits.KILOMETERS
+                Router.DistanceUnits.MILES.toString() -> return MapzenRouter.DistanceUnits.MILES
+                Router.DistanceUnits.KILOMETERS.toString() -> return MapzenRouter.DistanceUnits.KILOMETERS
             }
 
-            return Router.DistanceUnits.KILOMETERS
+            return MapzenRouter.DistanceUnits.KILOMETERS
         }
         set(value) {
             prefs.edit().putString(KEY_DISTANCE_UNITS, value.toString()).commit()
@@ -151,9 +152,9 @@ class AndroidAppSettings(val application: EraserMapApplication) : AppSettings {
         if (distanceUnitsPref == null) {
             val locale = Locale.getDefault()
             if (locale == Locale.US || locale == Locale.UK) {
-                this.distanceUnits = Router.DistanceUnits.MILES
+                this.distanceUnits = MapzenRouter.DistanceUnits.MILES
             } else {
-                this.distanceUnits = Router.DistanceUnits.KILOMETERS
+                this.distanceUnits = MapzenRouter.DistanceUnits.KILOMETERS
             }
         }
     }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/AppSettings.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/AppSettings.kt
@@ -3,12 +3,12 @@ package com.mapzen.erasermap.model
 import android.content.Context
 import android.location.Location
 import com.mapzen.android.MapzenMap
+import com.mapzen.android.MapzenRouter
 import com.mapzen.pelias.SavedSearch
-import com.mapzen.valhalla.Router
 import java.io.File
 
 interface AppSettings {
-    var distanceUnits: Router.DistanceUnits
+    var distanceUnits: MapzenRouter.DistanceUnits
     var isMockLocationEnabled: Boolean
     var mockLocation: Location
     var isMockRouteEnabled: Boolean

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/Http.java
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/Http.java
@@ -1,0 +1,6 @@
+package com.mapzen.erasermap.model;
+
+public interface Http {
+  String HEADER_DNT = "DNT";
+  String VALUE_HEADER_DNT = "1";
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/RouterFactory.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/RouterFactory.kt
@@ -1,7 +1,8 @@
 package com.mapzen.erasermap.model
 
-import com.mapzen.valhalla.Router
+import android.content.Context
+import com.mapzen.android.MapzenRouter
 
 interface RouterFactory {
-    public fun getRouter(): Router
+    public fun getRouter(context: Context): MapzenRouter
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/TileHttpHandler.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/TileHttpHandler.kt
@@ -9,8 +9,6 @@ import java.io.File
 public class TileHttpHandler(application: Application) : HttpHandler() {
     companion object {
         @JvmStatic val KITKAT = 19
-        @JvmStatic val HEADER_DNT = "DNT"
-        @JvmStatic val VALUE_HEADER_DNT = "1"
     }
 
     init {
@@ -18,7 +16,7 @@ public class TileHttpHandler(application: Application) : HttpHandler() {
             val httpCache = File(application.externalCacheDir.absolutePath + "/tile_cache")
             setCache(httpCache, 30 * 1024 * 1024)
         }
-        okRequestBuilder.addHeader(HEADER_DNT, VALUE_HEADER_DNT)
+        okRequestBuilder.addHeader(Http.HEADER_DNT, Http.VALUE_HEADER_DNT)
     }
 
     var apiKey: String? = null

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaHttpHandler.java
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaHttpHandler.java
@@ -1,25 +1,24 @@
 package com.mapzen.erasermap.model;
 
+import com.mapzen.android.TurnByTurnHttpHandler;
 import com.mapzen.valhalla.HttpHandler;
 
 import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 
-public class ValhallaHttpHandler extends HttpHandler {
+public class ValhallaHttpHandler extends TurnByTurnHttpHandler {
 
-  public ValhallaHttpHandler(String apiKey) {
-    super(apiKey);
+  public ValhallaHttpHandler(String endpoint, RestAdapter.LogLevel logLevel) {
+    configure(endpoint, logLevel);
   }
 
-  public ValhallaHttpHandler(String apiKey, RestAdapter.LogLevel logLevel) {
-    super(apiKey, logLevel);
+  public ValhallaHttpHandler(RestAdapter.LogLevel logLevel) {
+    configure(DEFAULT_URL, logLevel);
   }
 
-  public ValhallaHttpHandler(String apiKey, String endpoint, RestAdapter.LogLevel logLevel) {
-    super(apiKey, endpoint, logLevel);
-  }
-
-  protected void addHeadersForRequest(RequestInterceptor.RequestFacade requestFacade) {
+  @Override
+  protected void onRequest(RequestInterceptor.RequestFacade requestFacade) {
+    super.onRequest(requestFacade);
     requestFacade.addHeader(Http.HEADER_DNT, Http.VALUE_HEADER_DNT);
   }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaHttpHandler.java
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaHttpHandler.java
@@ -1,0 +1,25 @@
+package com.mapzen.erasermap.model;
+
+import com.mapzen.valhalla.HttpHandler;
+
+import retrofit.RequestInterceptor;
+import retrofit.RestAdapter;
+
+public class ValhallaHttpHandler extends HttpHandler {
+
+  public ValhallaHttpHandler(String apiKey) {
+    super(apiKey);
+  }
+
+  public ValhallaHttpHandler(String apiKey, RestAdapter.LogLevel logLevel) {
+    super(apiKey, logLevel);
+  }
+
+  public ValhallaHttpHandler(String apiKey, String endpoint, RestAdapter.LogLevel logLevel) {
+    super(apiKey, endpoint, logLevel);
+  }
+
+  protected void addHeadersForRequest(RequestInterceptor.RequestFacade requestFacade) {
+    requestFacade.addHeader(Http.HEADER_DNT, Http.VALUE_HEADER_DNT);
+  }
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.model
 
 import android.content.Context
+import android.util.Log
 import com.mapzen.android.MapzenRouter
 import com.mapzen.erasermap.BuildConfig
 import com.mapzen.model.ValhallaLocation
@@ -82,16 +83,20 @@ public class ValhallaRouteManager(val settings: AppSettings,
     }
 
     private fun getInitializedRouter(type: Router.Type): MapzenRouter {
-        val endpoint = BuildConfig.ROUTE_BASE_URL ?: ValhallaRouter.DEFAULT_URL
+        val endpoint = BuildConfig.ROUTE_BASE_URL ?: null
         val logLevel = if (BuildConfig.DEBUG) RestAdapter.LogLevel.FULL else
             RestAdapter.LogLevel.NONE
-        routerFactory.getRouter(context).router
-                .setApiKey(apiKey)
-                .setEndpoint(endpoint)
-                .setLogLevel(logLevel)
-                .setDntEnabled(true)
+        var httpHandler: ValhallaHttpHandler?
+        if  (endpoint != null) {
+            httpHandler = ValhallaHttpHandler(apiKey, endpoint, logLevel)
+        } else {
+            httpHandler = ValhallaHttpHandler(apiKey, logLevel)
+        }
+
         val router = routerFactory.getRouter(context)
-            when(type) {
+        router.router.setHttpHandler(httpHandler)
+
+        when(type) {
             Router.Type.DRIVING -> return router.setDriving()
             Router.Type.WALKING -> return router.setWalking()
             Router.Type.BIKING -> return router.setBiking()

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.model
 
-import android.location.Location
+import android.content.Context
+import com.mapzen.android.MapzenRouter
 import com.mapzen.erasermap.BuildConfig
 import com.mapzen.model.ValhallaLocation
 import com.mapzen.pelias.SimpleFeature
@@ -12,7 +13,7 @@ import com.mapzen.valhalla.ValhallaRouter
 import retrofit.RestAdapter
 
 public class ValhallaRouteManager(val settings: AppSettings,
-        val routerFactory: RouterFactory) : RouteManager {
+        val routerFactory: RouterFactory, val context: Context) : RouteManager {
     override var apiKey: String = ""
     override var origin: ValhallaLocation? = null
     override var destination: Feature? = null
@@ -39,7 +40,7 @@ public class ValhallaRouteManager(val settings: AppSettings,
         if (location is ValhallaLocation) {
             val start: DoubleArray = doubleArrayOf(location.latitude, location.longitude)
             val dest: DoubleArray = doubleArrayOf(simpleFeature.lat(), simpleFeature.lng())
-            val units: Router.DistanceUnits = settings.distanceUnits
+            val units: MapzenRouter.DistanceUnits = settings.distanceUnits
             var name: String? = null
 
             if (!simpleFeature.isAddress) {
@@ -70,7 +71,7 @@ public class ValhallaRouteManager(val settings: AppSettings,
         if (location is ValhallaLocation) {
             val start: DoubleArray = doubleArrayOf(simpleFeature.lat(), simpleFeature.lng())
             val dest: DoubleArray = doubleArrayOf(location.latitude, location.longitude)
-            val units: Router.DistanceUnits = settings.distanceUnits
+            val units: MapzenRouter.DistanceUnits = settings.distanceUnits
             getInitializedRouter(type)
                     .setLocation(start)
                     .setLocation(dest)
@@ -80,16 +81,17 @@ public class ValhallaRouteManager(val settings: AppSettings,
         }
     }
 
-    private fun getInitializedRouter(type: Router.Type): Router {
+    private fun getInitializedRouter(type: Router.Type): MapzenRouter {
         val endpoint = BuildConfig.ROUTE_BASE_URL ?: ValhallaRouter.DEFAULT_URL
         val logLevel = if (BuildConfig.DEBUG) RestAdapter.LogLevel.FULL else
             RestAdapter.LogLevel.NONE
-        val router = routerFactory.getRouter()
+        routerFactory.getRouter(context).router
                 .setApiKey(apiKey)
                 .setEndpoint(endpoint)
                 .setLogLevel(logLevel)
                 .setDntEnabled(true)
-        when(type) {
+        val router = routerFactory.getRouter(context)
+            when(type) {
             Router.Type.DRIVING -> return router.setDriving()
             Router.Type.WALKING -> return router.setWalking()
             Router.Type.BIKING -> return router.setBiking()

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
@@ -88,10 +88,11 @@ public class ValhallaRouteManager(val settings: AppSettings,
             RestAdapter.LogLevel.NONE
         var httpHandler: ValhallaHttpHandler?
         if  (endpoint != null) {
-            httpHandler = ValhallaHttpHandler(apiKey, endpoint, logLevel)
+            httpHandler = ValhallaHttpHandler(endpoint, logLevel)
         } else {
-            httpHandler = ValhallaHttpHandler(apiKey, logLevel)
+            httpHandler = ValhallaHttpHandler(logLevel)
         }
+        httpHandler.setApiKey(apiKey);
 
         val router = routerFactory.getRouter(context)
         router.router.setHttpHandler(httpHandler)

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouterFactory.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouterFactory.kt
@@ -1,10 +1,10 @@
 package com.mapzen.erasermap.model
 
-import com.mapzen.valhalla.Router
-import com.mapzen.valhalla.ValhallaRouter
+import android.content.Context
+import com.mapzen.android.MapzenRouter
 
 public class ValhallaRouterFactory : RouterFactory {
-    override fun getRouter(): Router {
-        return ValhallaRouter()
+    override fun getRouter(context: Context): MapzenRouter {
+        return MapzenRouter(context)
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/DistanceView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/DistanceView.kt
@@ -3,9 +3,9 @@ package com.mapzen.erasermap.view
 import android.content.Context
 import android.util.AttributeSet
 import android.widget.TextView
+import com.mapzen.android.MapzenDistanceFormatter
 import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.model.AppSettings
-import com.mapzen.helpers.DistanceFormatter
 import javax.inject.Inject
 
 public class DistanceView(context: Context, attrs: AttributeSet) : TextView(context, attrs) {
@@ -19,6 +19,6 @@ public class DistanceView(context: Context, attrs: AttributeSet) : TextView(cont
     public var distanceInMeters: Int = 0
         set (value) {
             field = value
-            text = DistanceFormatter.format(value, true, settings.distanceUnits)
+            text = MapzenDistanceFormatter.format(value, true, settings.distanceUnits)
         }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestAppSettings.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestAppSettings.kt
@@ -3,13 +3,14 @@ package com.mapzen.erasermap.model
 import android.content.Context
 import android.location.Location
 import com.mapzen.android.MapzenMap
+import com.mapzen.android.MapzenRouter
 import com.mapzen.erasermap.dummy.TestHelper
 import com.mapzen.pelias.SavedSearch
 import com.mapzen.valhalla.Router
 import java.io.File
 
 public class TestAppSettings : AppSettings {
-    override var distanceUnits: Router.DistanceUnits = Router.DistanceUnits.MILES
+    override var distanceUnits: MapzenRouter.DistanceUnits = MapzenRouter.DistanceUnits.MILES
     override var isMockLocationEnabled: Boolean = false
     override var mockLocation: Location = TestHelper.getTestAndroidLocation()
     override var isMockRouteEnabled: Boolean = false

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouter.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouter.kt
@@ -1,20 +1,21 @@
 package com.mapzen.erasermap.model
 
+import android.content.Context
+import com.mapzen.android.MapzenRouter
 import com.mapzen.valhalla.JSON
 import com.mapzen.valhalla.RouteCallback
 import com.mapzen.valhalla.Router
 import retrofit.RestAdapter
 import java.util.ArrayList
 
-public class TestRouter : Router {
+public class TestRouter(context: Context) : MapzenRouter(context) {
     public var locations: ArrayList<DoubleArray> = ArrayList()
     public var isFetching: Boolean = false
-    public var units: Router.DistanceUnits = Router.DistanceUnits.MILES
+    public var units: MapzenRouter.DistanceUnits = MapzenRouter.DistanceUnits.MILES
     public var bearing: Float = 0f
     public var name: String? = null
-    public var logLevel: RestAdapter.LogLevel = RestAdapter.LogLevel.BASIC
 
-    override fun clearLocations(): Router {
+    override fun clearLocations(): MapzenRouter {
         locations.clear()
         return this
     }
@@ -23,71 +24,46 @@ public class TestRouter : Router {
         isFetching = true
     }
 
-    override fun getEndpoint(): String {
-        return ""
-    }
-
-    override fun getJSONRequest(): JSON {
-        return JSON()
-    }
-
-    override fun setApiKey(key: String): Router {
+    override fun setApiKey(key: String): MapzenRouter {
         return this
     }
 
-    override fun setBiking(): Router {
+    override fun setBiking(): MapzenRouter {
         return this
     }
 
-    override fun setCallback(callback: RouteCallback): Router {
+    override fun setCallback(callback: RouteCallback): MapzenRouter {
         return this
     }
 
-    override fun setDriving(): Router {
+    override fun setDriving(): MapzenRouter {
         return this
     }
 
-    override fun setEndpoint(url: String): Router {
-        return this
-    }
-
-    override fun setLocation(point: DoubleArray): Router {
+    override fun setLocation(point: DoubleArray): MapzenRouter {
         locations.add(point)
         return this
     }
 
-    override fun setLocation(point: DoubleArray, heading: Float): Router {
+    override fun setLocation(point: DoubleArray, heading: Float): MapzenRouter {
         locations.add(point)
         bearing = heading
         return this
     }
 
     override fun setLocation(point: DoubleArray, name: String?, street: String?, city: String?,
-            state: String?): Router {
+            state: String?): MapzenRouter {
         this.name = name
         locations.add(point)
         return this
     }
 
-    override fun setWalking(): Router {
+    override fun setWalking(): MapzenRouter {
         return this
     }
 
-    override fun setDistanceUnits(units: Router.DistanceUnits): Router {
+    override fun setDistanceUnits(units: MapzenRouter.DistanceUnits): MapzenRouter {
         this.units = units
-        return this
-    }
-
-    override fun setLogLevel(logLevel: RestAdapter.LogLevel): Router {
-        this.logLevel = logLevel
-        return this
-    }
-
-    override fun isDntEnabled(): Boolean {
-        return true
-    }
-
-    override fun setDntEnabled(enabled: Boolean): Router {
         return this
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouter.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouter.kt
@@ -2,10 +2,7 @@ package com.mapzen.erasermap.model
 
 import android.content.Context
 import com.mapzen.android.MapzenRouter
-import com.mapzen.valhalla.JSON
 import com.mapzen.valhalla.RouteCallback
-import com.mapzen.valhalla.Router
-import retrofit.RestAdapter
 import java.util.ArrayList
 
 public class TestRouter(context: Context) : MapzenRouter(context) {
@@ -22,10 +19,6 @@ public class TestRouter(context: Context) : MapzenRouter(context) {
 
     override fun fetch() {
         isFetching = true
-    }
-
-    override fun setApiKey(key: String): MapzenRouter {
-        return this
     }
 
     override fun setBiking(): MapzenRouter {

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouterFactory.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouterFactory.kt
@@ -1,11 +1,19 @@
 package com.mapzen.erasermap.model
 
-import com.mapzen.valhalla.Router
+import android.content.Context
+import com.mapzen.android.MapzenRouter
 
 public class TestRouterFactory : RouterFactory {
-    val router = TestRouter()
 
-    override fun getRouter(): Router {
-        return router
+    companion object {
+        var router: TestRouter? = null
+    }
+
+    override fun getRouter(context: Context): MapzenRouter {
+        if (router == null) {
+            router = TestRouter(context)
+        }
+        return router as MapzenRouter
+
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
@@ -1,14 +1,33 @@
 package com.mapzen.erasermap.model
 
+import android.content.Context
+import android.content.res.Resources
+import android.test.mock.MockContext
 import com.mapzen.erasermap.dummy.TestHelper
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito
 
 public class ValhallaRouteManagerTest {
     val routerFactory = TestRouterFactory()
-    val routeManager = ValhallaRouteManager(TestAppSettings(), routerFactory)
+    var routeManager: ValhallaRouteManager? = null
+    var router: TestRouter? = null
+
+    @Before fun setup() {
+        val context = Mockito.mock(Context::class.java);
+        val resources = Mockito.mock(Resources::class.java);
+        Mockito.`when`(context.resources).thenReturn(resources);
+        Mockito.`when`(context.packageName).thenReturn("test");
+        Mockito.`when`(resources.getIdentifier("turn_by_turn_key", "string",
+            "test")).thenReturn(1)
+        Mockito.`when`(resources.getString(1)).thenThrow(
+            Resources.NotFoundException::class.java)
+        routeManager = ValhallaRouteManager(TestAppSettings(), routerFactory, context)
+        router = routerFactory.getRouter(context) as TestRouter
+    }
 
     @Test fun shouldNotBeNull() {
         assertThat(routeManager).isNotNull()
@@ -16,19 +35,19 @@ public class ValhallaRouteManagerTest {
 
     @Test fun fetchRoute_shouldIncludeNameInRouteRequest() {
         val feature = TestHelper.getTestFeature()
-        routeManager.origin = TestHelper.getTestLocation()
-        routeManager.destination = feature
-        routeManager.fetchRoute(TestRouteCallback())
-        assertThat(routerFactory.router.name).isEqualTo("Name")
+        routeManager?.origin = TestHelper.getTestLocation()
+        routeManager?.destination = feature
+        routeManager?.fetchRoute(TestRouteCallback())
+        assertThat(router?.name).isEqualTo("Name")
     }
 
     @Test fun fetchRoute_shouldNotIncludeNameInRouteRequestIfFeatureIsAnAddress() {
         val feature = TestHelper.getTestFeature()
         feature.properties.layer = "address"
-        routeManager.origin = TestHelper.getTestLocation()
-        routeManager.destination = feature
-        routeManager.fetchRoute(TestRouteCallback())
-        assertThat(routerFactory.router.name).isNull()
+        routeManager?.origin = TestHelper.getTestLocation()
+        routeManager?.destination = feature
+        routeManager?.fetchRoute(TestRouteCallback())
+        assertThat(router?.name).isNull()
     }
 
     class TestRouteCallback : RouteCallback {

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
@@ -2,7 +2,6 @@ package com.mapzen.erasermap.model
 
 import android.content.Context
 import android.content.res.Resources
-import android.test.mock.MockContext
 import com.mapzen.erasermap.dummy.TestHelper
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
@@ -21,10 +20,9 @@ public class ValhallaRouteManagerTest {
         val resources = Mockito.mock(Resources::class.java);
         Mockito.`when`(context.resources).thenReturn(resources);
         Mockito.`when`(context.packageName).thenReturn("test");
-        Mockito.`when`(resources.getIdentifier("turn_by_turn_key", "string",
-            "test")).thenReturn(1)
-        Mockito.`when`(resources.getString(1)).thenThrow(
-            Resources.NotFoundException::class.java)
+        Mockito.`when`(context.applicationContext).thenReturn(context)
+        Mockito.`when`(resources.getIdentifier("turn_by_turn_key", "string", "test")).thenReturn(1)
+        Mockito.`when`(resources.getString(1)).thenThrow(Resources.NotFoundException::class.java)
         routeManager = ValhallaRouteManager(TestAppSettings(), routerFactory, context)
         router = routerFactory.getRouter(context) as TestRouter
     }


### PR DESCRIPTION
- Uses sdk's `MapzenRouter` api
- adds DNT header for all routing requests

Depends on: https://github.com/mapzen/android/pull/112