### PR TITLE
Allows null value for intent param in notification service

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/service/NotificationService.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/service/NotificationService.kt
@@ -13,7 +13,7 @@ class NotificationService : Service() {
 
     internal var binder: IBinder = NotificationBinder(this)
 
-    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         return Service.START_STICKY
     }
 


### PR DESCRIPTION
According to documentation null intent is valid input to [`Service.onStartCommand(Intent, int, int)`](https://developer.android.com/reference/android/app/Service.html#onStartCommand(android.content.Intent, int, int)). Modify Kotlin to allow nullable parameter.

Closes #620