### PR TITLE
Cancel route requests on exit route preview

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -16,6 +16,7 @@ import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.View.TRANSLATION_Y
 import android.view.animation.AccelerateDecelerateInterpolator
 import android.widget.Button
 import android.widget.ImageButton
@@ -209,7 +210,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
             permissionManager.grantPermissions()
         }
         presenter.onResume()
-        app?.onActivityResume()
+        app.onActivityResume()
         autoCompleteAdapter?.clear()
         autoCompleteAdapter?.notifyDataSetChanged()
         invalidateOptionsMenu()
@@ -222,7 +223,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
 
     override public fun onPause() {
         super.onPause()
-        app?.onActivityPause()
+        app.onActivityPause()
         if (mapzenMap?.isMyLocationEnabled != null && mapzenMap?.isMyLocationEnabled as Boolean
                 && !presenter.routingEnabled) {
             enableLocation = true
@@ -234,7 +235,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         super.onStop()
         PreferenceManager.getDefaultSharedPreferences(this)
                 .edit()
-                .putString(SavedSearch.TAG, savedSearch?.serialize())
+                .putString(SavedSearch.TAG, savedSearch.serialize())
                 .commit()
     }
 
@@ -266,8 +267,8 @@ class MainActivity : AppCompatActivity(), MainViewController,
             override fun onSingleTapUp(x: Float, y: Float): Boolean = false
             override fun onSingleTapConfirmed(x: Float, y: Float): Boolean {
                 confidenceHandler.longPressed = false
-                var coords = mapzenMap?.coordinatesAtScreenPosition(x.toDouble(), y.toDouble())
-                presenter?.reverseGeoLngLat = coords
+                val coords = mapzenMap?.coordinatesAtScreenPosition(x.toDouble(), y.toDouble())
+                presenter.reverseGeoLngLat = coords
                 poiTapPoint = floatArrayOf(x, y)
                 return true
             }
@@ -858,17 +859,17 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     private fun generateRawFeature(): Feature {
-        var rawFeature: Feature = Feature()
+        val rawFeature: Feature = Feature()
         rawFeature.geometry = Geometry()
         val coords = ArrayList<Double>()
-        coords.add(presenter?.reverseGeoLngLat?.longitude as Double)
-        coords.add(presenter?.reverseGeoLngLat?.latitude as Double)
+        coords.add(presenter.reverseGeoLngLat?.longitude as Double)
+        coords.add(presenter.reverseGeoLngLat?.latitude as Double)
         rawFeature.geometry.coordinates = coords
         val properties = Properties()
         val formatter = DecimalFormat(".####")
         formatter.roundingMode = RoundingMode.HALF_UP
-        val lng = formatter.format(presenter?.reverseGeoLngLat?.longitude as Double)
-        val lat = formatter.format(presenter?.reverseGeoLngLat?.latitude  as Double)
+        val lng = formatter.format(presenter.reverseGeoLngLat?.longitude as Double)
+        val lat = formatter.format(presenter.reverseGeoLngLat?.latitude  as Double)
         properties.name = "$lng, $lat"
         rawFeature.properties = properties
         return rawFeature
@@ -912,7 +913,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         // Determine the smallest axis-aligned box that contains the route longitude and latitude
         val start = route.first()
         val finish = route.last()
-        var routeBounds = AxisAlignedBoundingBox()
+        val routeBounds = AxisAlignedBoundingBox()
         routeBounds.center = PointD(start.longitude, start.latitude)
 
         for (p in route) {
@@ -937,7 +938,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         val zoomDelta = -Math.log(Math.max(scaleX, scaleY)) / Math.log(2.0)
 
         // Update map position and zoom
-        var map = mapzenMap
+        val map = mapzenMap
         if (map != null) {
             val z = map.zoom + zoomDelta.toFloat()
             map.zoom = z
@@ -1097,10 +1098,10 @@ class MainActivity : AppCompatActivity(), MainViewController,
         routeBtmContainer.visibility = View.VISIBLE
         distanceView.distanceInMeters = instructionDistances[0]
         destinationNameTextView.text = simpleFeature.name()
-        previewDirectionListView.adapter = DirectionListAdapter(this, instructionStrings, instructionTypes,
-                instructionDistances, routeManager.reverse)
-        val topContainerAnimator = ObjectAnimator.ofFloat(routeTopContainer, View.TRANSLATION_Y, -height)
-        val btmContainerAnimator = ObjectAnimator.ofFloat(routeBtmContainer, View.TRANSLATION_Y, 0f)
+        previewDirectionListView.adapter = DirectionListAdapter(this, instructionStrings,
+                instructionTypes, instructionDistances, routeManager.reverse)
+        val topContainerAnimator = ObjectAnimator.ofFloat(routeTopContainer, TRANSLATION_Y,-height)
+        val btmContainerAnimator = ObjectAnimator.ofFloat(routeBtmContainer, TRANSLATION_Y, 0f)
         val animations = AnimatorSet()
         animations.playTogether(topContainerAnimator, btmContainerAnimator)
         animations.duration = DIRECTION_LIST_ANIMATION_DURATION
@@ -1122,8 +1123,8 @@ class MainActivity : AppCompatActivity(), MainViewController,
         display.getSize(size);
         val height = size.y.toFloat();
 
-        val topContainerAnimator = ObjectAnimator.ofFloat(routeTopContainer, View.TRANSLATION_Y, 0f)
-        val btmContainerAnimator = ObjectAnimator.ofFloat(routeBtmContainer, View.TRANSLATION_Y, height)
+        val topContainerAnimator = ObjectAnimator.ofFloat(routeTopContainer, TRANSLATION_Y, 0f)
+        val btmContainerAnimator = ObjectAnimator.ofFloat(routeBtmContainer, TRANSLATION_Y, height)
         val animations = AnimatorSet()
         animations.playTogether(topContainerAnimator, btmContainerAnimator)
         animations.duration = DIRECTION_LIST_ANIMATION_DURATION
@@ -1216,9 +1217,9 @@ class MainActivity : AppCompatActivity(), MainViewController,
             val pointX = poiTapPoint?.get(0)?.toDouble()
             val pointY = poiTapPoint?.get(1)?.toDouble()
             if (pointX != null && pointY != null) {
-                var coords = mapzenMap?.coordinatesAtScreenPosition(pointX, pointY)
-                var lng = coords?.longitude
-                var lat = coords?.latitude
+                val coords = mapzenMap?.coordinatesAtScreenPosition(pointX, pointY)
+                val lng = coords?.longitude
+                val lat = coords?.latitude
                 if (lng != null && lat!= null) {
                     coordinates.add(lng)
                     coordinates.add(lat)

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -51,4 +51,5 @@ interface MainViewController {
     fun executeSearch(query: String)
     fun onCloseAllSearchResults()
     fun deactivateFindMeTracking()
+    fun cancelRouteRequest()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -1,6 +1,6 @@
 package com.mapzen.erasermap.controller
 
-import com.mapzen.model.ValhallaLocation
+import com.mapzen.pelias.SimpleFeature
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.tangram.LngLat
 import com.mapzen.valhalla.Route
@@ -24,7 +24,8 @@ interface MainViewController {
     fun collapseSearchView()
     fun expandSearchView()
     fun clearQuery()
-    fun showRoutePreview(location: ValhallaLocation, feature: Feature)
+    fun showRoutePreview(destination: SimpleFeature)
+    fun route()
     fun hideRoutePreview()
     fun hideRoutingMode()
     fun startRoutingMode(feature: Feature)
@@ -52,4 +53,6 @@ interface MainViewController {
     fun onCloseAllSearchResults()
     fun deactivateFindMeTracking()
     fun cancelRouteRequest()
+    fun layoutAttributionAboveOptions()
+    fun layoutFindMeAboveOptions()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
@@ -16,7 +16,7 @@ class ConfidenceHandler(val presenter: MainPresenter) {
             return false;
         }
         return confidence < CONFIDENCE_THRESHOLD
-                && presenter?.reverseGeoLngLat != null
+                && presenter.reverseGeoLngLat != null
     }
 
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/RouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/RouteManager.kt
@@ -1,20 +1,21 @@
 package com.mapzen.erasermap.model
 
-import android.location.Location
 import com.mapzen.model.ValhallaLocation
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import com.mapzen.valhalla.Router
 
-public interface RouteManager {
-    public var apiKey: String
-    public var origin: ValhallaLocation?
-    public var destination: Feature?
-    public var type: Router.Type
-    public var reverse: Boolean
-    public var route: Route?
-    public var bearing: Float?
-    public fun fetchRoute(callback: RouteCallback)
-    public fun toggleReverse()
+interface RouteManager {
+    var apiKey: String
+    var origin: ValhallaLocation?
+    var destination: Feature?
+    var type: Router.Type
+    var reverse: Boolean
+    var route: Route?
+    var bearing: Float?
+    var currentRequest: RouteCallback?
+
+    fun fetchRoute(callback: RouteCallback)
+    fun toggleReverse()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
@@ -1,7 +1,6 @@
 package com.mapzen.erasermap.model
 
 import android.content.Context
-import android.util.Log
 import com.mapzen.android.MapzenRouter
 import com.mapzen.erasermap.BuildConfig
 import com.mapzen.model.ValhallaLocation
@@ -10,10 +9,9 @@ import com.mapzen.pelias.gson.Feature
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import com.mapzen.valhalla.Router
-import com.mapzen.valhalla.ValhallaRouter
 import retrofit.RestAdapter
 
-public class ValhallaRouteManager(val settings: AppSettings,
+class ValhallaRouteManager(val settings: AppSettings,
         val routerFactory: RouterFactory, val context: Context) : RouteManager {
     override var apiKey: String = ""
     override var origin: ValhallaLocation? = null
@@ -22,8 +20,10 @@ public class ValhallaRouteManager(val settings: AppSettings,
     override var reverse: Boolean = false
     override var route: Route? = null
     override var bearing: Float? = null
+    override var currentRequest: RouteCallback? = null
 
     override fun fetchRoute(callback: RouteCallback) {
+        currentRequest = callback
         if (reverse) {
             fetchReverseRoute(callback)
         } else {
@@ -86,7 +86,7 @@ public class ValhallaRouteManager(val settings: AppSettings,
         val endpoint = BuildConfig.ROUTE_BASE_URL ?: null
         val logLevel = if (BuildConfig.DEBUG) RestAdapter.LogLevel.FULL else
             RestAdapter.LogLevel.NONE
-        var httpHandler: ValhallaHttpHandler?
+        val httpHandler: ValhallaHttpHandler?
         if  (endpoint != null) {
             httpHandler = ValhallaHttpHandler(endpoint, logLevel)
         } else {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -52,4 +52,5 @@ interface MainPresenter {
     fun configureMapzenMap()
     fun onIntentQueryReceived(query: String?)
     fun onRouteRequest(callback: RouteCallback)
+    fun generateRawFeature(): Feature
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -1,6 +1,5 @@
 package com.mapzen.erasermap.presenter
 
-import android.location.Location
 import com.mapzen.erasermap.controller.MainViewController
 import com.mapzen.erasermap.view.RouteViewController
 import com.mapzen.model.ValhallaLocation
@@ -8,8 +7,9 @@ import com.mapzen.pelias.PeliasLocationProvider
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.gson.Result
 import com.mapzen.tangram.LngLat
+import com.mapzen.valhalla.RouteCallback
 
-public interface MainPresenter {
+interface MainPresenter {
     companion object {
         val LONG_MANEUVER_ZOOM: Float = 15f
         val DEFAULT_ZOOM: Float = 16f
@@ -17,38 +17,39 @@ public interface MainPresenter {
         val ROUTING_TILT: Float = 0.96f // 55°
     }
 
-    public var mainViewController: MainViewController?
-    public var routeViewController: RouteViewController?
-    public var currentSearchTerm: String?
-    public var currentFeature: Feature?
-    public var routingEnabled: Boolean
-    public var resultListVisible: Boolean
-    public var reverseGeo: Boolean
-    public var reverseGeoLngLat: LngLat?
+    var mainViewController: MainViewController?
+    var routeViewController: RouteViewController?
+    var currentSearchTerm: String?
+    var currentFeature: Feature?
+    var routingEnabled: Boolean
+    var resultListVisible: Boolean
+    var reverseGeo: Boolean
+    var reverseGeoLngLat: LngLat?
 
-    public fun onSearchResultsAvailable(result: Result?)
-    public fun onReverseGeocodeResultsAvailable(searchResults: Result?)
-    public fun onPlaceSearchResultsAvailable(searchResults: Result?)
-    public fun onSearchResultSelected(position: Int)
-    public fun onSearchResultTapped(position: Int)
-    public fun onExpandSearchView()
-    public fun onCollapseSearchView()
-    public fun onClickViewList()
-    public fun onClickStartNavigation()
-    public fun onQuerySubmit()
-    public fun onViewAllSearchResults()
-    public fun updateLocation()
-    public fun onBackPressed()
-    public fun onRestoreViewState()
-    public fun onResume()
-    public fun onMuteClick()
-    public fun onCompassClick()
-    public fun getPeliasLocationProvider(): PeliasLocationProvider
-    public fun onReroute(location: ValhallaLocation)
-    public fun onMapMotionEvent(): Boolean
-    public fun onReverseGeoRequested(screenX: Float?, screenY: Float?): Boolean
-    public fun onPlaceSearchRequested(gid: String): Boolean
-    public fun onExitNavigation()
-    public fun configureMapzenMap()
-    public fun onIntentQueryReceived(query: String?)
+    fun onSearchResultsAvailable(result: Result?)
+    fun onReverseGeocodeResultsAvailable(searchResults: Result?)
+    fun onPlaceSearchResultsAvailable(searchResults: Result?)
+    fun onSearchResultSelected(position: Int)
+    fun onSearchResultTapped(position: Int)
+    fun onExpandSearchView()
+    fun onCollapseSearchView()
+    fun onClickViewList()
+    fun onClickStartNavigation()
+    fun onQuerySubmit()
+    fun onViewAllSearchResults()
+    fun updateLocation()
+    fun onBackPressed()
+    fun onRestoreViewState()
+    fun onResume()
+    fun onMuteClick()
+    fun onCompassClick()
+    fun getPeliasLocationProvider(): PeliasLocationProvider
+    fun onReroute(location: ValhallaLocation)
+    fun onMapMotionEvent(): Boolean
+    fun onReverseGeoRequested(screenX: Float?, screenY: Float?): Boolean
+    fun onPlaceSearchRequested(gid: String): Boolean
+    fun onExitNavigation()
+    fun configureMapzenMap()
+    fun onIntentQueryReceived(query: String?)
+    fun onRouteRequest(callback: RouteCallback)
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -276,6 +276,9 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
             restoreReverseGeoOnBack = false
             reverseGeo = true
         }
+
+        mainViewController?.hideProgress()
+        mainViewController?.cancelRouteRequest()
         mainViewController?.hideRoutePreview()
         mainViewController?.clearRoute()
         if (searchResults != null) {
@@ -483,5 +486,11 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
         mainViewController?.hideSettingsBtn()
         mainViewController?.hideSearchResults()
         mainViewController?.executeSearch(queryString)
+    }
+
+    override fun onRouteRequest(callback: RouteCallback) {
+        mainViewController?.showProgress()
+        mainViewController?.cancelRouteRequest()
+        routeManager.fetchRoute(callback)
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -36,6 +36,7 @@ class TestMainController : MainViewController {
     var isSettingsVisible: Boolean = false
     var isFindMeTrackingEnabled: Boolean = false
     var popBackStack: Boolean = false
+    var routeRequestCanceled: Boolean = false
 
     override fun showSearchResults(features: List<Feature>?) {
         searchResults = features
@@ -209,5 +210,9 @@ class TestMainController : MainViewController {
 
     override fun deactivateFindMeTracking() {
         isFindMeTrackingEnabled = false
+    }
+
+    override fun cancelRouteRequest() {
+        routeRequestCanceled = true
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -1,7 +1,7 @@
 package com.mapzen.erasermap.controller
 
 import android.graphics.PointF
-import com.mapzen.model.ValhallaLocation
+import com.mapzen.pelias.SimpleFeature
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.tangram.LngLat
 import com.mapzen.valhalla.Route
@@ -92,8 +92,11 @@ class TestMainController : MainViewController {
         queryText = ""
     }
 
-    override fun showRoutePreview(location: ValhallaLocation, feature: Feature) {
+    override fun showRoutePreview(destination: SimpleFeature) {
         isRoutePreviewVisible = true
+    }
+
+    override fun route() {
     }
 
     override fun hideRoutePreview() {
@@ -214,5 +217,11 @@ class TestMainController : MainViewController {
 
     override fun cancelRouteRequest() {
         routeRequestCanceled = true
+    }
+
+    override fun layoutAttributionAboveOptions() {
+    }
+
+    override fun layoutFindMeAboveOptions() {
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouteManager.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouteManager.kt
@@ -9,13 +9,14 @@ import com.mapzen.valhalla.Router
 import org.json.JSONObject
 import java.util.ArrayList
 
-public class TestRouteManager : RouteManager {
+class TestRouteManager : RouteManager {
     override var origin: ValhallaLocation? = null
     override var destination: Feature? = null
     override var type: Router.Type = Router.Type.DRIVING
     override var reverse: Boolean = false
     override var route: Route? = null
     override var bearing: Float? = null
+    override var currentRequest: RouteCallback? = null
 
     override fun fetchRoute(callback: RouteCallback) {
         route = TestRoute()
@@ -25,13 +26,13 @@ public class TestRouteManager : RouteManager {
         reverse = !reverse
     }
 
-    public var locations: ArrayList<DoubleArray> = ArrayList()
-    public var isFetching: Boolean = false
-    public var units: Router.DistanceUnits = Router.DistanceUnits.MILES
+    var locations: ArrayList<DoubleArray> = ArrayList()
+    var isFetching: Boolean = false
+    var units: Router.DistanceUnits = Router.DistanceUnits.MILES
 
     override var apiKey: String = BuildConfig.VALHALLA_API_KEY
 
-    public fun reset() {
+    fun reset() {
         locations.clear()
         origin = null
         destination = null
@@ -39,6 +40,6 @@ public class TestRouteManager : RouteManager {
         bearing = null
     }
 
-    public inner class TestRoute : Route(JSONObject()) {
+    inner class TestRoute : Route(JSONObject()) {
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
@@ -2,7 +2,8 @@ package com.mapzen.erasermap.model
 
 import android.content.Context
 import android.content.res.Resources
-import com.mapzen.erasermap.dummy.TestHelper
+import com.mapzen.erasermap.dummy.TestHelper.getTestFeature
+import com.mapzen.erasermap.dummy.TestHelper.getTestLocation
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 import org.assertj.core.api.Assertions.assertThat
@@ -10,7 +11,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito
 
-public class ValhallaRouteManagerTest {
+class ValhallaRouteManagerTest {
     val routerFactory = TestRouterFactory()
     var routeManager: ValhallaRouteManager? = null
     var router: TestRouter? = null
@@ -32,20 +33,32 @@ public class ValhallaRouteManagerTest {
     }
 
     @Test fun fetchRoute_shouldIncludeNameInRouteRequest() {
-        val feature = TestHelper.getTestFeature()
-        routeManager?.origin = TestHelper.getTestLocation()
+        val feature = getTestFeature()
+        routeManager?.origin = getTestLocation()
         routeManager?.destination = feature
         routeManager?.fetchRoute(TestRouteCallback())
         assertThat(router?.name).isEqualTo("Name")
     }
 
     @Test fun fetchRoute_shouldNotIncludeNameInRouteRequestIfFeatureIsAnAddress() {
-        val feature = TestHelper.getTestFeature()
+        val feature = getTestFeature()
         feature.properties.layer = "address"
-        routeManager?.origin = TestHelper.getTestLocation()
+        routeManager?.origin = getTestLocation()
         routeManager?.destination = feature
         routeManager?.fetchRoute(TestRouteCallback())
         assertThat(router?.name).isNull()
+    }
+
+    @Test fun currentRequest_shouldReturnNull() {
+        assertThat(routeManager?.currentRequest).isNull()
+    }
+
+    @Test fun currentRequest_shouldReturnLastCallback() {
+        val callback = TestRouteCallback()
+        routeManager?.origin = getTestLocation()
+        routeManager?.destination = getTestFeature()
+        routeManager?.fetchRoute(callback)
+        assertThat(routeManager?.currentRequest).isEqualTo(callback)
     }
 
     class TestRouteCallback : RouteCallback {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -11,6 +11,7 @@ import com.mapzen.erasermap.model.LocationConverter
 import com.mapzen.erasermap.model.TestAppSettings
 import com.mapzen.erasermap.model.TestMapzenLocation
 import com.mapzen.erasermap.model.TestRouteManager
+import com.mapzen.erasermap.model.ValhallaRouteManagerTest.TestRouteCallback
 import com.mapzen.erasermap.model.event.LocationChangeEvent
 import com.mapzen.erasermap.model.event.RouteCancelEvent
 import com.mapzen.erasermap.model.event.RouteEvent
@@ -397,6 +398,20 @@ class MainPresenterTest {
         assertThat(vsm.viewState).isEqualTo(DEFAULT)
     }
 
+    @Test fun onBackPressed_shouldHideProgressInStateRoutePreview() {
+        vsm.viewState = ROUTE_PREVIEW
+        mainController.isProgressVisible = true
+        presenter.onBackPressed()
+        assertThat(mainController.isProgressVisible).isFalse()
+    }
+
+    @Test fun onBackPressed_shouldCancelRouteRequestInStateRoutePreview() {
+        vsm.viewState = ROUTE_PREVIEW
+        mainController.routeRequestCanceled = false
+        presenter.onBackPressed()
+        assertThat(mainController.routeRequestCanceled).isTrue()
+    }
+
     @Test fun configureMapzenMap_shouldSetMapLocationFirstTimeInvoked() {
         presenter.configureMapzenMap()
         assertThat(mainController.lngLat).isNotNull()
@@ -573,6 +588,23 @@ class MainPresenterTest {
         `when`(iqp.parse(input)).thenReturn(IntentQuery("test_query", expected))
         presenter.onIntentQueryReceived(input)
         assertThat(mainController.lngLat).isEqualTo(expected)
+    }
+
+    @Test fun onRouteRequest_shouldShowProgress() {
+        mainController.isProgressVisible = false
+        presenter.onRouteRequest(TestRouteCallback())
+        assertThat(mainController.isProgressVisible).isTrue()
+    }
+
+    @Test fun onRouteRequest_shouldCancelRequest() {
+        mainController.routeRequestCanceled = false
+        presenter.onRouteRequest(TestRouteCallback())
+        assertThat(mainController.routeRequestCanceled).isTrue()
+    }
+
+    @Test fun onRouteRequest_shouldFetchRoute() {
+        presenter.onRouteRequest(TestRouteCallback())
+        assertThat(routeManager.route).isNotNull()
     }
 
     class RouteEventSubscriber {


### PR DESCRIPTION
Adds pseudo-cancellation for route requests by ignoring the response if a request has been canceled.

**Request Cancellation**

A route request is canceled if:

1. The user presses the system back button while the route preview is being generated (slow request, etc.)
2. The user switches routing mode (car, bike, walk) when a request for the previous mode is not yet complete.

**Refactoring**

Moves route fetch logic from `MainActivity` to `MainPresenter`. Ideally all references to `RouteManager` will be removed from `MainActivity` over time but this will require additional refactoring.

**Code Cleanup**

* Remove unused imports.
* Delete public scope modifier when implied for variables and functions.

Closes #626