### PR TITLE
Adds `else` condition to `when` statement to fix compile error

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
@@ -101,6 +101,7 @@ class ValhallaRouteManager(val settings: AppSettings,
             Router.Type.DRIVING -> return router.setDriving()
             Router.Type.WALKING -> return router.setWalking()
             Router.Type.BIKING -> return router.setBiking()
+            else -> return router.setDriving()
         }
     }
 }


### PR DESCRIPTION
> Building 71% > :app:compileDevDebugKotline: /home/ubuntu/eraser-map/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt: (105, 5): A 'return' expression required in a function with a block body ('{...}')