### PR TITLE
Hide resume button on exit routing mode

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -1176,6 +1176,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         supportActionBar?.hide()
         routeModeView.route = null
         routeModeView.hideRouteIcon()
+        routeModeView.hideResumeButton()
         hideReverseGeolocateResult()
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -1117,7 +1117,18 @@ class MainActivity : AppCompatActivity(), MainViewController,
         animations.start()
     }
 
-    override fun startRoutingMode(feature: Feature) {
+    /**
+     * Create and/or update routing mode UI.
+     *
+     * @param feature the current destination.
+     * @param isNew true if the call is for a new route; false if this call is for a reroute.
+     */
+    override fun startRoutingMode(feature: Feature, isNew: Boolean) {
+        if (isNew) {
+            // Resume button should be hidden at the start of a new route.
+            routeModeView.hideResumeButton()
+        }
+
         // Set camera before RouteModeView#startRoute so that MapzenMap#sceneUpdate called
         // before MapzenMap#queueEvent
         setRoutingCamera()

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -28,7 +28,7 @@ interface MainViewController {
     fun route()
     fun hideRoutePreview()
     fun hideRoutingMode()
-    fun startRoutingMode(feature: Feature)
+    fun startRoutingMode(feature: Feature, isNew: Boolean)
     fun resumeRoutingMode(feature: Feature)
     fun shutDown()
     fun centerMapOnLocation(lngLat: LngLat, zoom: Float)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -332,7 +332,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     override fun onClickStartNavigation() {
         bus.post(RouteEvent())
         mainViewController?.resetMute() //must call before generateRoutingMode()
-        generateRoutingMode()
+        generateRoutingMode(true)
         vsm.viewState = ViewStateManager.ViewState.ROUTING
         routeViewController?.hideResumeButton()
         mapzenLocation.startLocationUpdates()
@@ -400,7 +400,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     override fun success(route: Route) {
         mainViewController?.hideProgress()
         routeManager.route = route
-        generateRoutingMode()
+        generateRoutingMode(false)
         mainViewController?.drawRoute(route)
         waitingForRoute = false
     }
@@ -414,11 +414,11 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
         }
     }
 
-    private fun generateRoutingMode() {
+    private fun generateRoutingMode(isNew: Boolean) {
         routingEnabled = true
         val feature = destination
         if (feature is Feature) {
-            mainViewController?.startRoutingMode(feature)
+            mainViewController?.startRoutingMode(feature, isNew)
         }
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -37,6 +37,7 @@ class TestMainController : MainViewController {
     var isFindMeTrackingEnabled: Boolean = false
     var popBackStack: Boolean = false
     var routeRequestCanceled: Boolean = false
+    var isNew: Boolean = false
 
     override fun showSearchResults(features: List<Feature>?) {
         searchResults = features
@@ -118,8 +119,9 @@ class TestMainController : MainViewController {
         isRoutingModeVisible = false
     }
 
-    override fun startRoutingMode(feature: Feature) {
+    override fun startRoutingMode(feature: Feature, isNew: Boolean) {
         isRoutingModeVisible = true
+        this.isNew = isNew
     }
 
     override fun resumeRoutingMode(feature: Feature) {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -321,11 +321,11 @@ class MainPresenterTest {
 
     @Test fun onStartRoutingMode_shouldNotResetMute() {
         mainController.muted = true
-        mainController.startRoutingMode(getTestFeature())
+        mainController.startRoutingMode(getTestFeature(), true)
         assertThat(mainController.muted).isTrue()
 
         mainController.muted = false
-        mainController.startRoutingMode(getTestFeature())
+        mainController.startRoutingMode(getTestFeature(), false)
         assertThat(mainController.muted).isFalse()
     }
 
@@ -605,6 +605,20 @@ class MainPresenterTest {
     @Test fun onRouteRequest_shouldFetchRoute() {
         presenter.onRouteRequest(TestRouteCallback())
         assertThat(routeManager.route).isNotNull()
+    }
+
+    @Test fun onClickStartNavigation_shouldSetIsNewTrue() {
+        mainController.isNew = false
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onClickStartNavigation()
+        assertThat(mainController.isNew).isTrue()
+    }
+
+    @Test fun onRerouteSuccess_shouldSetIsNewFalse() {
+        mainController.isNew = true
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.success(Route(JSONObject()))
+        assertThat(mainController.isNew).isFalse()
     }
 
     class RouteEventSubscriber {


### PR DESCRIPTION
Explicitly hide the resume button when exiting routing mode. This ensures the correct camera and map position is set when starting a new route.

Fixes #602