### PR TITLE
Don't show "now" in directions list, only show in instructions

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/view/DistanceView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/DistanceView.kt
@@ -12,6 +12,8 @@ public class DistanceView(context: Context, attrs: AttributeSet) : TextView(cont
 
     @Inject lateinit var settings: AppSettings
 
+    var realTime = false
+
     init {
         (context.applicationContext as EraserMapApplication).component().inject(this)
     }
@@ -19,6 +21,6 @@ public class DistanceView(context: Context, attrs: AttributeSet) : TextView(cont
     public var distanceInMeters: Int = 0
         set (value) {
             field = value
-            text = MapzenDistanceFormatter.format(value, true, settings.distanceUnits)
+            text = MapzenDistanceFormatter.format(value, realTime, settings.distanceUnits)
         }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/InstructionAdapter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/InstructionAdapter.kt
@@ -27,6 +27,7 @@ class InstructionAdapter(private val context: Context,
         val icon = view.findViewById(R.id.icon) as ImageView
         val turn = instruction.getIntegerInstruction()
         val iconId: Int = DisplayHelper.getRouteDrawable(context, turn, true)
+        distance.realTime = true
         distance.distanceInMeters = instruction.distance
         title.text = instruction.getName()
         icon.setImageResource(iconId)


### PR DESCRIPTION
Shows distance:
![screenshot_20160622-125656](https://cloud.githubusercontent.com/assets/494323/16276315/cf1a4d8c-387b-11e6-96f6-7db6d94a71c4.png)

Shows now:
![screenshot_20160622-125636](https://cloud.githubusercontent.com/assets/494323/16276311/cd835ed2-387b-11e6-996c-a486fd2da0a3.png)

Closes #647 