### PR TITLE
limit station icons

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -504,6 +504,7 @@ class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPageChangeL
 
     override fun hideRouteLine() {
         mapzenMap?.clearRouteLine()
+        mapzenMap?.clearTransitRouteLine()
     }
 
     fun clearRoute() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -489,10 +489,10 @@ class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPageChangeL
                         val stationPoints = ArrayList<LngLat>()
                         if (instruction.getTransitInfo() != null) {
                             val stops = instruction.getTransitInfo()!!.getTransitStops()
-                            for (transitStop in stops) {
-                                stationPoints.add(LngLat(transitStop.getLon(),
-                                    transitStop.getLat()))
-                            }
+                            val firstStop = stops[0]
+                            stationPoints.add(LngLat(firstStop.getLon(), firstStop.getLat()))
+                            val lastStop = stops[stops.size-1]
+                            stationPoints.add(LngLat(lastStop.getLon(), lastStop.getLat()))
                         }
                         mapzenMap?.drawTransitRouteLine(points, stationPoints,
                             instruction.getTransitInfoColorHex() as String)


### PR DESCRIPTION
- Showing all the icons clutters the UI, this PR only shows the first/last station icons
- This also fixes the transit route line not being cleared from the map

Closes #687 