### PR TITLE
Route preview jumping

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -1009,7 +1009,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
 
     private fun reverse() {
         routeManager.toggleReverse()
-        routePreviewView.reverse = routeManager.reverse ?: false
+        routePreviewView.reverse = routeManager.reverse
         route()
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -125,6 +125,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     val mapView: MapView by lazy { findViewById(R.id.map) as MapView }
     val compass: CompassView by lazy { findViewById(R.id.compass_view) as CompassView }
     val searchController: SearchViewController by lazy { findViewById(R.id.search_results) as SearchResultsView }
+    val progressContainer: RelativeLayout by lazy { findViewById(R.id.progress_container) as RelativeLayout }
 
     // view_route_preview
     val routePreviewView: RoutePreviewView by lazy { findViewById(R.id.route_preview) as RoutePreviewView }
@@ -787,11 +788,11 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     override fun showProgress() {
-        findViewById(R.id.progress)?.visibility = View.VISIBLE
+        progressContainer.visibility = View.VISIBLE
     }
 
     override fun hideProgress() {
-        findViewById(R.id.progress)?.visibility = View.GONE
+        progressContainer.visibility = View.GONE
     }
 
     override fun onSearchResultSelected(position: Int) {
@@ -852,7 +853,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         })
         updateRoutePreview()
         routeModeView.drawRoute(route, routeManager.type)
-        routePreviewView.enableStartNavigation(routeManager.type)
+        routePreviewView.enableStartNavigation(routeManager.type, routeManager.reverse)
         hideProgress()
     }
 
@@ -977,7 +978,6 @@ class MainActivity : AppCompatActivity(), MainViewController,
             if (isChecked) {
                 routeManager.type = Router.Type.DRIVING
                 route()
-                safeShowStartNavigation()
             }
         }
 
@@ -985,7 +985,6 @@ class MainActivity : AppCompatActivity(), MainViewController,
             if (isChecked) {
                 routeManager.type = Router.Type.BIKING
                 route()
-                safeShowStartNavigation()
             }
         }
 
@@ -993,7 +992,6 @@ class MainActivity : AppCompatActivity(), MainViewController,
             if (isChecked) {
                 routeManager.type = Router.Type.WALKING
                 route()
-                safeShowStartNavigation()
             }
         }
 
@@ -1001,21 +999,12 @@ class MainActivity : AppCompatActivity(), MainViewController,
             if (isChecked) {
                 routeManager.type = Router.Type.MULTIMODAL
                 route()
-                startNavigationButton.visibility = View.GONE
             }
         }
     }
 
     override fun restoreRoutePreviewButtons() {
-        if (routeManager.type == Router.Type.MULTIMODAL) {
-            startNavigationButton.visibility = View.GONE
-        }
-    }
-
-    private fun safeShowStartNavigation() {
-        if (!routePreviewView.reverse) {
-            startNavigationButton.visibility = View.VISIBLE
-        }
+        routePreviewView.restore(routeManager)
     }
 
     private fun reverse() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
@@ -57,7 +57,6 @@ class RoutePreviewView : RelativeLayout {
                 startView.setText(R.string.current_location)
                 destinationView.text = destination?.name()
                 startNavigationButton.visibility = VISIBLE
-
             }
         }
 
@@ -103,9 +102,11 @@ class RoutePreviewView : RelativeLayout {
         tryAnotherMode.visibility = View.VISIBLE
     }
 
-    fun enableStartNavigation(type: Router.Type) {
-        if (type != Router.Type.MULTIMODAL) {
+    fun enableStartNavigation(type: Router.Type, reverse: Boolean) {
+        if (type != Router.Type.MULTIMODAL && !reverse) {
             startNavigationButton.visibility = View.VISIBLE
+        } else {
+            startNavigationButton.visibility = View.GONE
         }
         viewListButton.visibility = View.VISIBLE
         noRouteFound.visibility = View.GONE
@@ -199,4 +200,9 @@ class RoutePreviewView : RelativeLayout {
         animations.start()
     }
 
+    fun restore(routeManager: RouteManager) {
+        if (routeManager.type == Router.Type.MULTIMODAL || routeManager.reverse) {
+            startNavigationButton.visibility = View.GONE
+        }
+    }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
@@ -204,5 +204,6 @@ class RoutePreviewView : RelativeLayout {
         if (routeManager.type == Router.Type.MULTIMODAL || routeManager.reverse) {
             startNavigationButton.visibility = View.GONE
         }
+        reverse = routeManager.reverse
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -24,7 +24,7 @@
         tools:ignore="RtlHardcoded" />
 
     <RelativeLayout
-        android:id="@+id/progress"
+        android:id="@+id/progress_container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/transparent_light_gray"

--- a/app/src/main/res/layout/route_header.xml
+++ b/app/src/main/res/layout/route_header.xml
@@ -25,7 +25,7 @@
 
         <LinearLayout
             android:id="@+id/start_location_layout"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal">
 
@@ -51,7 +51,7 @@
 
         <LinearLayout
             android:id="@+id/destination_layout"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="horizontal">
 

--- a/app/src/main/res/layout/view_route_preview.xml
+++ b/app/src/main/res/layout/view_route_preview.xml
@@ -133,7 +133,7 @@
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="48dp"
                 android:orientation="horizontal"
                 android:layout_margin="16dp"
                 style="?android:attr/buttonBarStyle">
@@ -169,7 +169,7 @@
                 <TextView
                     android:id="@+id/no_route_found"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="match_parent"
                     android:background="@color/gray"
                     android:textColor="@color/mz_white"
                     android:textSize="@dimen/font_medium"
@@ -181,6 +181,7 @@
                     />
 
             </LinearLayout>
+
         </LinearLayout>
     </RelativeLayout>
 


### PR DESCRIPTION
- Fix jumping when switching between modes by setting defined container height (previously it wrapped content)
- Add progressContainer reference
- Move setting of `RoutePreviewView` subview visibility into `RoutePreviewView`
- Fix route preview reverse not being restored on orientation change

Closes #690 