### PR TITLE
Dont update start nav visibility when setting reverse

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
@@ -52,11 +52,9 @@ class RoutePreviewView : RelativeLayout {
             if (value) {
                 startView.text = destination?.name()
                 destinationView.setText(R.string.current_location)
-                startNavigationButton.visibility = GONE
             } else {
                 startView.setText(R.string.current_location)
                 destinationView.text = destination?.name()
-                startNavigationButton.visibility = VISIBLE
             }
         }
 


### PR DESCRIPTION
This PR makes it so that we only update the text views when changing the value of `reverse`. When `reverse` is changed, we issue a route request and upon completion of the request we update `startNavigationButton` 's visibility, taking the values of `reverse` and route mode into account.

Closes #696 