### PR TITLE
Fix crash on API < 23 devices when debug menu enabled

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SettingsFragment.kt
@@ -173,8 +173,8 @@ public class SettingsFragment : PreferenceFragment(), Preference.OnPreferenceCha
     }
 
     private fun initTangramVersionPref() {
-        findPreference(AndroidAppSettings.KEY_TANGRAM_VERSION).summary = context.getString(
-            R.string.tangram_version)
+        findPreference(AndroidAppSettings.KEY_TANGRAM_VERSION).summary =
+                getString(R.string.tangram_version)
     }
 
     private fun getSettingsActivity(): SettingsActivity {


### PR DESCRIPTION
Replaces `Fragment.getContext().getString()` (API 23) with `Fragment.getString()` (API 11) in `SettingsFragment` debug menu.

Fixes #708