### PR TITLE
mapzen-android-sdk:1.0.10-SNAPSHOT

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -130,7 +130,7 @@ dependencies {
   compile 'com.android.support:appcompat-v7:23.4.0'
   compile 'com.android.support:support-v4:23.4.0'
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  compile 'com.mapzen:mapzen-android-sdk:1.0.8'
+  compile 'com.mapzen:mapzen-android-sdk:1.0.10-SNAPSHOT'
   compile "com.google.dagger:dagger:$dagger_version"
   compile 'com.squareup:otto:1.3.7'
   compile 'com.splunk.mint:mint:4.2.1'


### PR DESCRIPTION
Updates to mapzen-android-sdk:1.0.10-SNAPSHOT which uses tangram 0.4.2