### PR TITLE
Unified API Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Privacy-focused mapping application for Android
 ## API Keys
 1. Go to https://mapzen.com/developers/ and auth with Github
 2. Create a Mapzen API key
-3. Add keys to `~/.gradle/gradle.properties` or use as command line arguments
+3. Add key to `~/.gradle/gradle.properties` or use as command line argument
 
 
 **gradle.properties**

--- a/README.md
+++ b/README.md
@@ -6,24 +6,20 @@ Privacy-focused mapping application for Android
 
 ## API Keys
 1. Go to https://mapzen.com/developers/ and auth with Github
-2. Create Mapzen Search, Turn By Turn, and Vector Tiles keys
+2. Create a Mapzen API key
 3. Add keys to `~/.gradle/gradle.properties` or use as command line arguments
 
 
 **gradle.properties**
 
 ```bash
-vectorTileApiKey=vector-tiles-???
-peliasApiKey=search-???
-valhallaApiKey=valhalla-???
+apiKey=mapzen-???
 ```
 
 **Command-line arguments**
 
 ```bash
-./gradlew clean installDebug -PvectorTileApiKey=$VECTOR_TILE_API_KEY \
-    -PpeliasApiKey=$PELIAS_API_KEY \
-    -PvalhallaApiKey=$VALHALLA_API_KEY
+./gradlew clean installDebug -PapiKey=$API_KEY
 ```
 
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,9 +17,7 @@ apply plugin: 'checkstyle'
 def SEARCH_BASE_URL = hasProperty('searchBaseUrl') ? '"' + searchBaseUrl + '"' : "null";
 def ROUTE_BASE_URL = hasProperty('routeBaseUrl') ? '"' + routeBaseUrl + '"' : "null";
 
-def VECTOR_TILE_API_KEY = hasProperty('vectorTileApiKey') ? '"' + vectorTileApiKey + '"' : "null";
-def PELIAS_API_KEY = hasProperty('peliasApiKey') ? '"' + peliasApiKey + '"' : "null";
-def VALHALLA_API_KEY = hasProperty('valhallaApiKey') ? '"' + valhallaApiKey + '"' : "null";
+def API_KEY = hasProperty('apiKey') ? '"' + apiKey + '"' : "null";
 def MINT_API_KEY = hasProperty('mintApiKey') ? '"' + mintApiKey + '"' : "null";
 def BUILD_NUMBER = hasProperty('buildNumber') ? '"' + buildNumber + '"' : '"DEV"';
 
@@ -40,9 +38,7 @@ android {
     versionName version
     buildConfigField "String", "SEARCH_BASE_URL", SEARCH_BASE_URL
     buildConfigField "String", "ROUTE_BASE_URL", ROUTE_BASE_URL
-    buildConfigField "String", "VECTOR_TILE_API_KEY", VECTOR_TILE_API_KEY
-    buildConfigField "String", "PELIAS_API_KEY", PELIAS_API_KEY
-    buildConfigField "String", "VALHALLA_API_KEY", VALHALLA_API_KEY
+    buildConfigField "String", "API_KEY", API_KEY
     buildConfigField "String", "MINT_API_KEY", MINT_API_KEY
     buildConfigField "String", "BUILD_NUMBER", BUILD_NUMBER
   }

--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -83,13 +83,13 @@ public class AndroidModule {
     @Provides @Singleton RouteManager provideRouteManager(AppSettings settings, ApiKeys apiKeys) {
         final ValhallaRouteManager manager = new ValhallaRouteManager(settings,
                 new ValhallaRouterFactory(), application.getApplicationContext());
-        manager.setApiKey(apiKeys.getRoutingKey());
+        manager.setApiKey(apiKeys.getApiKey());
         return manager;
     }
 
     @Provides @Singleton TileHttpHandler provideTileHttpHandler(ApiKeys apiKeys) {
         final TileHttpHandler handler = new TileHttpHandler(application);
-        handler.setApiKey(apiKeys.getTilesKey());
+        handler.setApiKey(apiKeys.getApiKey());
         return handler;
     }
 
@@ -113,7 +113,7 @@ public class AndroidModule {
 
             @Override public Map<String, String> queryParamsForRequest() {
                 Map<String, String> params = new HashMap<>();
-                params.put(ApiKeyConstants.API_KEY, apiKeys.getSearchKey());
+                params.put(ApiKeyConstants.API_KEY, apiKeys.getApiKey());
                 return params;
             }
         });

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -234,7 +234,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     private fun initMapzenMap() {
-        mapView.getMapAsync(apiKeys.tilesKey, {
+        mapView.getMapAsync(apiKeys.apiKey, {
             this.mapzenMap = it
             configureMapzenMap()
             presenter.configureMapzenMap()

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
@@ -8,9 +8,7 @@ import com.mapzen.erasermap.EraserMapApplication
  */
 class ApiKeys private constructor(val application: EraserMapApplication) {
 
-    lateinit var tilesKey: String
-    lateinit var searchKey: String
-    lateinit var routingKey: String
+    lateinit var apiKey: String
 
     companion object {
         var instance: ApiKeys? = null
@@ -25,14 +23,10 @@ class ApiKeys private constructor(val application: EraserMapApplication) {
 
     init {
         configureKeys()
-        if (tilesKey.isEmpty()) throw IllegalArgumentException("Tiles key cannot be empty.")
-        if (searchKey.isEmpty()) throw IllegalArgumentException("Search key cannot be empty.")
-        if (routingKey.isEmpty()) throw IllegalArgumentException("Routing key cannot be empty.")
+        if (apiKey.isEmpty()) throw IllegalArgumentException("Api key cannot be empty.")
     }
 
     private fun configureKeys() {
-        tilesKey = BuildConfig.VECTOR_TILE_API_KEY
-        searchKey = BuildConfig.PELIAS_API_KEY
-        routingKey = BuildConfig.VALHALLA_API_KEY
+        apiKey = BuildConfig.API_KEY
     }
 }

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -80,7 +80,7 @@ public class TestAndroidModule {
 
     @Provides @Singleton TileHttpHandler provideTileHttpHandler() {
         TileHttpHandler handler = new TileHttpHandler(application);
-        handler.setApiKey(BuildConfig.VECTOR_TILE_API_KEY);
+        handler.setApiKey(BuildConfig.API_KEY);
         return handler;
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
@@ -16,21 +16,9 @@ class ApiKeysTest {
         assertThat(apiKeys).isNotNull()
     }
 
-    @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptyTilesKey() {
+    @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptyApiKey() {
         PowerMockito.mockStatic(BuildConfig::class.java)
-        Mockito.doReturn(null).`when`(BuildConfig.VECTOR_TILE_API_KEY)
-        ApiKeys.Companion.sharedInstance(application)
-    }
-
-    @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptySearchKey() {
-        PowerMockito.mockStatic(BuildConfig::class.java)
-        Mockito.doReturn(null).`when`(BuildConfig.PELIAS_API_KEY)
-        ApiKeys.Companion.sharedInstance(application)
-    }
-
-    @Test(expected = IllegalArgumentException::class) fun shouldNotAcceptEmptyRoutingKey() {
-        PowerMockito.mockStatic(BuildConfig::class.java)
-        Mockito.doReturn(null).`when`(BuildConfig.VALHALLA_API_KEY)
+        Mockito.doReturn(null).`when`(BuildConfig.API_KEY)
         ApiKeys.Companion.sharedInstance(application)
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouteManager.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouteManager.kt
@@ -30,7 +30,7 @@ class TestRouteManager : RouteManager {
     var isFetching: Boolean = false
     var units: Router.DistanceUnits = Router.DistanceUnits.MILES
 
-    override var apiKey: String = BuildConfig.VALHALLA_API_KEY
+    override var apiKey: String = BuildConfig.API_KEY
 
     fun reset() {
         locations.clear()

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
     ANDROID_HOME: /usr/local/android-sdk-linux
     JAVA_OPTS: "-Xmx256m -XX:MaxPermSize=256m"
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx256m -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError"'
-    TEST_OPTS: "-PmintApiKey=mint_test_key -PvectorTileApiKey=tile_test_key -PpeliasApiKey=search_test_key -PvalhallaApiKey=route_test_key -PbuildNumber=test_build_number"
+    TEST_OPTS: "-PmintApiKey=mint_test_key -PapiKey=test_api_key -PbuildNumber=test_build_number"
 
 dependencies:
   pre:

--- a/scripts/deploy-master.sh
+++ b/scripts/deploy-master.sh
@@ -2,6 +2,6 @@
 #
 # Builds master branch and uploads APK to s3://android.mapzen.com/erasermap-snapshots/.
 
-./gradlew assembleDevDebug -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY -PpeliasApiKey=$PELIAS_API_KEY -PvalhallaApiKey=$VALHALLA_API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM -PsearchBaseUrl="$SEARCH_BASE_URL" -ProuteBaseUrl="$ROUTE_BASE_URL"
+./gradlew assembleDevDebug -PmintApiKey=$MINT_API_KEY -PapiKey=$API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM -PsearchBaseUrl="$SEARCH_BASE_URL" -ProuteBaseUrl="$ROUTE_BASE_URL"
 s3cmd put app/build/outputs/apk/app-dev-debug.apk s3://android.mapzen.com/erasermap-latest.apk
 s3cmd put app/build/outputs/apk/app-dev-debug.apk s3://android.mapzen.com/erasermap-snapshots/master-$CIRCLE_BUILD_NUM.apk

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,11 +4,11 @@
 
 if [ -z ${PERFORM_RELEASE} ]
   then
-    ./gradlew assembleDevDebug -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY -PpeliasApiKey=$PELIAS_API_KEY -PvalhallaApiKey=$VALHALLA_API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM -PsearchBaseUrl="$SEARCH_BASE_URL" -ProuteBaseUrl="$ROUTE_BASE_URL"
+    ./gradlew assembleDevDebug -PmintApiKey=$MINT_API_KEY -PapiKey=$API_KEY -PbuildNumber=$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM -PsearchBaseUrl="$SEARCH_BASE_URL" -ProuteBaseUrl="$ROUTE_BASE_URL"
     s3cmd put app/build/outputs/apk/app-dev-debug.apk s3://android.mapzen.com/erasermap-development/$CIRCLE_BRANCH-$CIRCLE_BUILD_NUM.apk
   else
     cd app && git clone $CONFIG_REPO
     cd ..
-    ./gradlew clean assembleProdRelease --refresh-dependencies -PmintApiKey=$MINT_API_KEY -PvectorTileApiKey=$VECTOR_TILE_API_KEY_PROD -PpeliasApiKey=$PELIAS_API_KEY_PROD -PvalhallaApiKey=$VALHALLA_API_KEY_PROD -PbuildNumber=$RELEASE_TAG -PreleaseStoreFile=$RELEASE_STORE_FILE -PreleaseStorePassword="$RELEASE_STORE_PASSWORD" -PreleaseKeyAlias=$RELEASE_KEY_ALIAS -PreleaseKeyPassword="$RELEASE_KEY_PASSWORD" -PsearchBaseUrl="$SEARCH_BASE_URL" -ProuteBaseUrl="$ROUTE_BASE_URL"
+    ./gradlew clean assembleProdRelease --refresh-dependencies -PmintApiKey=$MINT_API_KEY -PapiKey=$API_KEY_PROD -PbuildNumber=$RELEASE_TAG -PreleaseStoreFile=$RELEASE_STORE_FILE -PreleaseStorePassword="$RELEASE_STORE_PASSWORD" -PreleaseKeyAlias=$RELEASE_KEY_ALIAS -PreleaseKeyPassword="$RELEASE_KEY_PASSWORD" -PsearchBaseUrl="$SEARCH_BASE_URL" -ProuteBaseUrl="$ROUTE_BASE_URL"
     s3cmd put app/build/outputs/apk/app-prod-release.apk s3://android.mapzen.com/erasermap-releases/$RELEASE_TAG.apk
 fi


### PR DESCRIPTION
- Migrates from 3 keys to 1
- Updates documentation
- Updates deploy scripts

Testing Instructions:
- Update `~/.gradle/gradle.properties` to remove old keys and replace with `apiKey=[API_KEY]`

TODO:
- [x] Update https://github.com/mapzen/android-config to remove old keys
- [x] Decide if we should generate new key or use any existing for `apiKey` (discuss analytics)
- [x] Add keys into circle `API_KEY` and `API_KEY_PROD`
- [ ] Remove old keys from circle

Closes #727 