### PR TITLE
Fix location running in bg

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -214,6 +214,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
                 && !presenter.routingEnabled) {
             enableLocation = true
             mapzenMap?.isMyLocationEnabled = false
+            lostClientManager.disconnect()
         }
     }
 
@@ -229,6 +230,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         super.onDestroy()
         saveCurrentSearchTerm()
         mapzenMap?.isMyLocationEnabled = false
+        lostClientManager.disconnect()
         killNotifications()
         voiceNavigationController?.shutdown()
     }


### PR DESCRIPTION
Two `LostApiClient` objects are connected when the app launches. One is via the Mapzen SDK and another via the `LostClientManager` in EM. We were properly disconnecting the one created in the Mapzen SDK via `mapzenMap?.isMyLocationEnabled = false` but not the one in `LostClientManager`. This PR disconnects EM's `LostApiClient` which removes all of the clients from Lost's underlying client manager and allows the `FusedLocationProviderApi` to disconnect.

Closes #731 