### PR TITLE
Fix Crash

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/model/MapzenLocationImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/MapzenLocationImpl.kt
@@ -53,7 +53,7 @@ public class MapzenLocationImpl(val locationClientManager: LocationClientManager
 
     private var previousLocation: Location? = null
 
-    private fun connect() {
+    private fun configureMockSettings() {
         val locationClient = locationClientManager.getClient()
         if (settings.isMockLocationEnabled) {
             LocationServices.FusedLocationApi?.setMockMode(locationClient, true)
@@ -68,7 +68,7 @@ public class MapzenLocationImpl(val locationClientManager: LocationClientManager
         if (!permissionManager.permissionsGranted()) {
             return null
         }
-        connect()
+        configureMockSettings()
         val client = locationClientManager.getClient()
         return LocationServices.FusedLocationApi?.getLastLocation(client)
     }
@@ -77,7 +77,7 @@ public class MapzenLocationImpl(val locationClientManager: LocationClientManager
         if (!permissionManager.permissionsGranted()) {
             return
         }
-        connect()
+        configureMockSettings()
         val client = locationClientManager.getClient()
         LocationServices.FusedLocationApi?.requestLocationUpdates(client, request, locationListener)
     }


### PR DESCRIPTION
## Overview

This PR fixes a crash caused by the `LostApiClient` being unexpectedly disconnected. It updates the `MapzenLocationImpl` to unregister the listener it registers when `stopLocationUpdates()` is called instead of disconnecting the client. This behavior is more symmetrical to `startLocationUpdates()`.
## Proposed Changes

When the app launches both the SDK and EM create and connect `LostApiClient`s. The first time a route starts, the SDK's client is disconnected when the "find me" button is hidden (this is expected), EM's client remains connected, and location updates are registered for (also expected). When the user backs out of a route, location updates are stopped and EM's client is disconnected (unexpected) but the underlying service remains connected because the SDK's client is connected. Then, the next time a route is started, `onClickStartNavigation` checks that the client is connected (it is because the SDK's client is). Then, before location updates are registered for, the "find me" button is hidden and because no other clients are connected, the service is disconnected. This PR prevents the `LostApiClient` connection state from being modified after it is checked by keeping EM's client connected.

Closes #740 
