### PR TITLE
Reconnect EM lost client when enabling location

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -1189,6 +1189,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     override fun checkPermissionAndEnableLocation() {
         if (permissionManager.granted && !presenter.routingEnabled) {
             mapzenMap?.isMyLocationEnabled = true
+            lostClientManager.connect()
             if (settings.isMockLocationEnabled) {
                 if (lostClientManager.getClient() == null) {
                     lostClientManager.connect()


### PR DESCRIPTION
This fixes a crash that occurs when the app is backgrounded and then re-opened. We need to reconnect EM's client because it is not connected via map initialization.