### PR TITLE
Removes LostClientManager connection state

### DIFF
--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -2,7 +2,6 @@ package com.mapzen.erasermap;
 
 import com.mapzen.android.core.ApiKeyConstants;
 import com.mapzen.android.search.MapzenSearch;
-import com.mapzen.android.lost.api.LostApiClient;
 import com.mapzen.erasermap.model.AndroidAppSettings;
 import com.mapzen.erasermap.model.ApiKeys;
 import com.mapzen.erasermap.model.AppSettings;
@@ -75,9 +74,11 @@ public class AndroidModule {
     @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation, Bus bus,
             RouteManager routeManager, AppSettings settings, ViewStateManager vsm,
             IntentQueryParser intentQueryParser, LocationConverter converter,
-            LostClientManager clientManager, LocationSettingsChecker locationSettingsChecker) {
+            LostClientManager clientManager, LocationSettingsChecker locationSettingsChecker,
+            PermissionManager permissionManager) {
         return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm,
-                intentQueryParser, converter, clientManager, locationSettingsChecker);
+                intentQueryParser, converter, clientManager, locationSettingsChecker,
+                permissionManager);
     }
 
     @Provides @Singleton RouteManager provideRouteManager(AppSettings settings, ApiKeys apiKeys) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -1173,8 +1173,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
             grantResults: IntArray) {
         when (requestCode) {
             PERMISSIONS_REQUEST -> {
-                if (grantResults.size > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                if (grantResults.size > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     permissionManager.grantPermissions()
                     checkPermissionAndEnableLocation()
                     val findMe = mapView.findViewById(R.id.mz_find_me);
@@ -1185,22 +1184,11 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     override fun checkPermissionAndEnableLocation() {
-        if (permissionManager.granted && !presenter.routingEnabled) {
-            mapzenMap?.isMyLocationEnabled = true
-            lostClientManager.connect()
-            if (settings.isMockLocationEnabled) {
-                if (!lostClientManager.getClient().isConnected) {
-                    lostClientManager.connect()
-                    lostClientManager.addRunnableToRunOnConnect(
-                        Runnable { checkPermissionAndEnableLocation() }
-                    )
-                    return
-                }
-                val client = lostClientManager.getClient()
-                LocationServices.FusedLocationApi?.setMockMode(client, true)
-                LocationServices.FusedLocationApi?.setMockLocation(client, settings.mockLocation)
-            }
-        }
+        presenter.checkPermissionAndEnableLocation()
+    }
+
+    override fun setMyLocationEnabled(enabled: Boolean) {
+        mapzenMap?.isMyLocationEnabled = enabled
     }
 
     override fun executeSearch(query: String) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -1189,7 +1189,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
             mapzenMap?.isMyLocationEnabled = true
             lostClientManager.connect()
             if (settings.isMockLocationEnabled) {
-                if (lostClientManager.getClient() == null) {
+                if (!lostClientManager.getClient().isConnected) {
                     lostClientManager.connect()
                     lostClientManager.addRunnableToRunOnConnect(
                         Runnable { checkPermissionAndEnableLocation() }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -58,4 +58,5 @@ interface MainViewController {
     fun layoutFindMeAboveOptions()
     fun restoreRoutePreviewButtons()
     fun handleLocationResolutionRequired(status: Status)
+    fun setMyLocationEnabled(enabled: Boolean)
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/LocationClientManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/LocationClientManager.kt
@@ -4,7 +4,7 @@ import com.mapzen.android.lost.api.LostApiClient
 
 interface LocationClientManager {
 
-  fun getClient(): LostApiClient?
+  fun getClient(): LostApiClient
   fun connect()
   fun disconnect()
   fun addRunnableToRunOnConnect(runnable: Runnable)

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/LostClientManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/LostClientManager.kt
@@ -7,19 +7,13 @@ import java.util.ArrayList
 /**
  * Manages [LostApiClient] and its [ConnectionCallback] flow
  */
-class LostClientManager(val application: Application, locationFactory: LocationFactory): LocationClientManager {
+class LostClientManager(val application: Application, locationFactory: LocationFactory):
+    LocationClientManager {
 
-  private enum class State {
-    CONNECTING, CONNECTED, IDLE
-  }
-
-  private var state = State.IDLE
-  private lateinit var lostClient: LostApiClient
+  private var lostClient: LostApiClient
   private val connectionCallbacks: LostApiClient.ConnectionCallbacks =
       object: LostApiClient.ConnectionCallbacks {
-
         override fun onConnected() {
-          state = State.CONNECTED
           for (runnable in runnables) {
             runnable.run()
           }
@@ -27,7 +21,6 @@ class LostClientManager(val application: Application, locationFactory: LocationF
         }
 
         override fun onConnectionSuspended() {
-          state = State.IDLE
         }
   }
   private var runnables = ArrayList<Runnable>()
@@ -36,25 +29,11 @@ class LostClientManager(val application: Application, locationFactory: LocationF
     lostClient = locationFactory.createClient(application, connectionCallbacks)
   }
 
-  override fun getClient(): LostApiClient? {
-    if (state != State.CONNECTED) {
-      return null
-    }
-    return lostClient
-  }
+  override fun getClient() = lostClient
 
-  override fun connect() {
-    if (state == State.CONNECTING) {
-      return
-    }
-    state = State.CONNECTING
-    lostClient.connect()
-  }
+  override fun connect()  = lostClient.connect()
 
-  override fun disconnect() {
-    lostClient.disconnect()
-    state = State.IDLE
-  }
+  override fun disconnect() = lostClient.disconnect()
 
   override fun addRunnableToRunOnConnect(runnable: Runnable) {
     runnables.add(runnable)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -54,4 +54,5 @@ interface MainPresenter {
     fun onRouteRequest(callback: RouteCallback)
     fun generateRawFeature(): Feature
     fun onFeaturePicked(properties: Map<String, String>, poiPoint: FloatArray)
+    fun checkPermissionAndEnableLocation()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -232,7 +232,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   @Subscribe fun onRoutePreviewEvent(event: RoutePreviewEvent) {
-    if (locationClientManager.getClient() == null) {
+    if (!locationClientManager.getClient().isConnected) {
       connectAndPostRunnable { onRoutePreviewEvent(event) }
       return
     }
@@ -264,7 +264,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   override fun updateLocation() {
-    if (locationClientManager.getClient() == null) {
+    if (!locationClientManager.getClient().isConnected) {
       connectAndPostRunnable { updateLocation() }
       return
     }
@@ -362,7 +362,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   override fun onClickStartNavigation() {
-    if (locationClientManager.getClient() == null) {
+    if (!locationClientManager.getClient().isConnected) {
       connectAndPostRunnable { onClickStartNavigation() }
       return
     }
@@ -443,7 +443,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   private fun generateRoutePreview() {
-    if (locationClientManager.getClient() == null) {
+    if (!locationClientManager.getClient().isConnected) {
       connectAndPostRunnable { generateRoutePreview() }
       return
     }
@@ -505,7 +505,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   override fun configureMapzenMap() {
-    if (locationClientManager.getClient() == null) {
+    if (!locationClientManager.getClient().isConnected) {
       connectAndPostRunnable { configureMapzenMap() }
       return
     }

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -69,9 +69,11 @@ public class TestAndroidModule {
     @Provides @Singleton MainPresenter provideMainPresenter(MapzenLocation mapzenLocation, Bus bus,
             RouteManager routeManager, AppSettings settings, ViewStateManager vsm,
             IntentQueryParser intentQueryParser, LocationConverter converter,
-        LostClientManager lostClientManager, LocationSettingsChecker locationSettingsChecker) {
+            LostClientManager lostClientManager, LocationSettingsChecker locationSettingsChecker,
+            PermissionManager permissionManager) {
         return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm,
-                intentQueryParser, converter, lostClientManager, locationSettingsChecker);
+                intentQueryParser, converter, lostClientManager, locationSettingsChecker,
+            permissionManager);
     }
 
     @Provides @Singleton RouteManager provideRouteManager() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -35,6 +35,7 @@ class TestMainController : MainViewController {
     var popBackStack: Boolean = false
     var routeRequestCanceled: Boolean = false
     var isNew: Boolean = false
+    var isCurrentLocationEnabled: Boolean = false
 
     var settingsApiTriggered: Boolean = false
 
@@ -234,5 +235,9 @@ class TestMainController : MainViewController {
 
     override fun handleLocationResolutionRequired(status: Status) {
         settingsApiTriggered = true
+    }
+
+    override fun setMyLocationEnabled(enabled: Boolean) {
+        isCurrentLocationEnabled = enabled
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/LostClientManagerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/LostClientManagerTest.kt
@@ -17,10 +17,6 @@ class LostClientManagerTest {
     clientManager = LostClientManager(application, testLostFactory)
   }
 
-  @Test fun getClient_shouldReturnNull() {
-    assertThat(clientManager?.getClient()).isNull()
-  }
-
   @Test fun getClient_shouldReturnClient() {
     testLostFactory.callbacks?.onConnected()
     assertThat(clientManager?.getClient()).isNotNull()

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/TestLostClientManager.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/TestLostClientManager.kt
@@ -3,23 +3,23 @@ package com.mapzen.erasermap.presenter
 import com.mapzen.android.lost.api.LostApiClient
 import com.mapzen.erasermap.model.LocationClientManager
 import org.mockito.Mockito
+import org.mockito.Mockito.`when`
 
 class TestLostClientManager: LocationClientManager {
 
-  override fun getClient(): LostApiClient? {
-    return Mockito.mock(LostApiClient::class.java)
+  override fun getClient(): LostApiClient {
+    val client = Mockito.mock(LostApiClient::class.java)
+    `when`(client.isConnected).thenReturn(true)
+    return client
   }
 
   override fun connect() {
-
   }
 
   override fun disconnect() {
-
   }
   
   override fun addRunnableToRunOnConnect(runnable: Runnable) {
-
   }
 
 }


### PR DESCRIPTION
In an effort to simplify location client management `LostClientManager` no longer actively tracks its connection state. Instead it relies on `LostApiClient.isConnected()` to return proper connection state.

`LostClientManager.getClient()` now always returns the client instance and is no longer nullable. Null checks on the client have been converted to calls to `isConnected()`.