### PR TITLE
Dont invoke client connect when already connected

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -1190,7 +1190,6 @@ class MainActivity : AppCompatActivity(), MainViewController,
             lostClientManager.connect()
             if (settings.isMockLocationEnabled) {
                 if (lostClientManager.getClient() == null) {
-                    lostClientManager.connect()
                     lostClientManager.addRunnableToRunOnConnect(
                         Runnable { checkPermissionAndEnableLocation() }
                     )

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/LostClientManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/LostClientManager.kt
@@ -44,7 +44,7 @@ class LostClientManager(val application: Application, locationFactory: LocationF
   }
 
   override fun connect() {
-    if (state == State.CONNECTING) {
+    if (state == State.CONNECTING || state == State.CONNECTED) {
       return
     }
     state = State.CONNECTING

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/LostClientManagerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/LostClientManagerTest.kt
@@ -31,6 +31,12 @@ class LostClientManagerTest {
     assertThat(testLostFactory.lostClient.connected).isTrue()
   }
 
+  @Test fun connect_shouldNotInvokeClientConnectWhenAlreadyConnected() {
+    clientManager?.connect()
+    clientManager?.connect()
+    assertThat(testLostFactory.lostClient.connectCount).isEqualTo(1)
+  }
+
   @Test fun addRunnableToRunOnConnect_shouldRunRunnable() {
     val testRunnable = TestRunnable()
     clientManager?.addRunnableToRunOnConnect(
@@ -58,6 +64,7 @@ class LostClientManagerTest {
 
     var connected = false
     var callbacks: LostApiClient.ConnectionCallbacks? = null
+    var connectCount = 0
 
     override fun disconnect() {
       connected = false
@@ -66,6 +73,7 @@ class LostClientManagerTest {
 
     override fun connect() {
       connected = true
+      connectCount++
       callbacks?.onConnected()
     }
 


### PR DESCRIPTION
This change fixes a crash caused when mock routing was enabled. Previously, calls to connect an already connected client created an infinite loop in `MainActivity#checkPermissionAndEnableLocation`. `LostApiClient#connect` invoked `ConnectionCallbacks#onConnected`. This would trigger queued runnables to run in `LostClientManager` which would start the loop again...now the underlying client will not be called if it is already connected.

Closes #751 