### PR TITLE
Center Map on Orientation Changes

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -31,6 +31,7 @@ interface MainViewController {
     fun hideRoutingMode()
     fun startRoutingMode(feature: Feature, isNew: Boolean)
     fun resumeRoutingMode(feature: Feature)
+    fun resumeRoutingModeForMap()
     fun shutDown()
     fun centerMapOnLocation(lngLat: LngLat, zoom: Float)
     fun setMapTilt(radians: Float)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -40,6 +40,7 @@ interface MainPresenter {
     fun updateLocation()
     fun onBackPressed()
     fun onRestoreViewState()
+    fun onRestoreMapState()
     fun onResume()
     fun onMuteClick()
     fun onCompassClick()

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenter.kt
@@ -19,6 +19,7 @@ interface RoutePresenter {
     fun onLocationChanged(location: ValhallaLocation)
     fun onRouteStart(route: Route?)
     fun onRouteResume(route: Route?)
+    fun onRouteResumeForMap(route: Route?)
     fun onMapPan(deltaX: Float, deltaY: Float)
     fun onResumeButtonClick()
     fun onInstructionPagerTouch()

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/RoutePresenterImpl.kt
@@ -1,6 +1,5 @@
 package com.mapzen.erasermap.presenter
 
-import android.location.Location
 import com.mapzen.erasermap.model.event.RouteCancelEvent
 import com.mapzen.erasermap.view.MapListToggleButton
 import com.mapzen.erasermap.view.RouteViewController
@@ -46,6 +45,9 @@ class RoutePresenterImpl(private val routeEngine: RouteEngine,
         if (!isTrackingCurrentLocation) {
             routeController?.showResumeButton()
         }
+    }
+
+    override fun onRouteResumeForMap(route: Route?) {
         val location = route?.getRouteInstructions()?.get(currentInstructionIndex)?.location
         if (location != null) {
             routeController?.showRouteIcon(location)

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -432,6 +432,10 @@ class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPageChangeL
         initInstructionAdapter()
         this.visibility = View.VISIBLE
         routePresenter.onRouteResume(route)
+    }
+
+    fun resumeRouteForMap() {
+        routePresenter.onRouteResumeForMap(route)
         Handler().postDelayed( {
             val currentSnapLocation = routePresenter.currentSnapLocation
             if (currentSnapLocation != null) {

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -36,6 +36,10 @@ class TestMainController : MainViewController {
     var routeRequestCanceled: Boolean = false
     var isNew: Boolean = false
     var isCurrentLocationEnabled: Boolean = false
+    var isAttributionAboveOptions = false
+    var isFindMeAboveOptions = false
+    var isRouting = false
+    var isRouteBtnVisibleAndMapCentered = false
 
     var settingsApiTriggered: Boolean = false
 
@@ -98,6 +102,7 @@ class TestMainController : MainViewController {
     }
 
     override fun route() {
+        isRouting = true
     }
 
     override fun hideRoutePreview() {
@@ -126,6 +131,10 @@ class TestMainController : MainViewController {
 
     override fun resumeRoutingMode(feature: Feature) {
         isRoutingModeVisible = true
+    }
+
+    override fun resumeRoutingModeForMap() {
+        isRouteBtnVisibleAndMapCentered = true
     }
 
     override fun centerMapOnLocation(lngLat: LngLat, zoom: Float) {
@@ -222,9 +231,11 @@ class TestMainController : MainViewController {
     }
 
     override fun layoutAttributionAboveOptions() {
+        isAttributionAboveOptions = true
     }
 
     override fun layoutFindMeAboveOptions() {
+        isFindMeAboveOptions = true
     }
 
     override fun restoreRoutePreviewButtons() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -124,7 +124,7 @@ class MainPresenterTest {
         assertThat(mainController.isPlaceResultOverridden).isTrue()
     }
 
-    @Test fun onRestoreViewState_shouldRestorePreviousSearchResults() {
+    @Test fun onRestoreMapState_shouldRestorePreviousSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()
         result.features = features
@@ -132,8 +132,50 @@ class MainPresenterTest {
 
         val newController = TestMainController()
         presenter.mainViewController = newController
-        presenter.onRestoreViewState()
+        presenter.onRestoreMapState()
         assertThat(newController.searchResults).isEqualTo(features)
+    }
+
+    @Test fun onRestoreMapState_shouldAdjustAttributionRoutePreview() {
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onRestoreMapState()
+        assertThat(mainController.isAttributionAboveOptions).isTrue()
+    }
+
+    @Test fun onRestoreMapState_shouldAdjustFindMeRoutePreview() {
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onRestoreMapState()
+        assertThat(mainController.isFindMeAboveOptions).isTrue()
+    }
+
+    @Test fun onRestoreMapState_shouldRouteRoutePreview() {
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onRestoreMapState()
+        assertThat(mainController.isRouting).isTrue()
+    }
+
+    @Test fun onRestoreMapState_shouldAdjustAttributionRoutePreviewList() {
+        presenter.onClickViewList()
+        presenter.onRestoreMapState()
+        assertThat(mainController.isAttributionAboveOptions).isTrue()
+    }
+
+    @Test fun onRestoreMapState_shouldAdjustFindMeRoutePreviewList() {
+        presenter.onClickViewList()
+        presenter.onRestoreMapState()
+        assertThat(mainController.isFindMeAboveOptions).isTrue()
+    }
+
+    @Test fun onRestoreMapState_shouldRouteRoutePreviewList() {
+        presenter.onClickViewList()
+        presenter.onRestoreMapState()
+        assertThat(mainController.isRouting).isTrue()
+    }
+
+    @Test fun onRestoreMapState_shouldShowRouteBtnAndCenterMapRouting() {
+        presenter.onClickStartNavigation()
+        presenter.onRestoreMapState()
+        assertThat(mainController.isRouteBtnVisibleAndMapCentered).isTrue()
     }
 
     @Test fun onRestoreViewState_shouldHideSettingsButtonWhileShowingSearchResults() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -7,6 +7,7 @@ import com.mapzen.erasermap.view.MapListToggleButton
 import com.mapzen.erasermap.view.TestRouteController
 import com.mapzen.helpers.RouteEngine
 import com.mapzen.model.ValhallaLocation
+import com.mapzen.tangram.LngLat
 import com.mapzen.valhalla.Route
 import com.squareup.otto.Bus
 import com.squareup.otto.Subscribe
@@ -56,6 +57,14 @@ class RoutePresenterTest {
         routeEngine.route = route1
         routePresenter.onRouteResume(route2)
         assertThat(routeEngine.route).isEqualTo(route1)
+    }
+
+    @Test fun onRouteResumeForMap_shouldDrawRouteLocationMarker() {
+        val route = Route(getFixture("valhalla_route"))
+        routePresenter.onRouteResumeForMap(route)
+        val location = route.getRouteInstructions()?.get(0)?.location
+        assertThat(routeController.routeLocationMarkerPos?.latitude).isEqualTo(location?.latitude)
+        assertThat(routeController.routeLocationMarkerPos?.longitude).isEqualTo(location?.longitude)
     }
 
     @Test fun onMapPan_shouldShowResumeButton() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/TestRouteController.kt
@@ -17,6 +17,7 @@ public class TestRouteController : RouteViewController {
     public var post: Int = -1
     public var mapZoom: Float = 0f
     public var displayIndex: Int = 0
+    var routeLocationMarkerPos: ValhallaLocation? = null
 
     override fun onLocationChanged(location: Location) {
         this.location = location
@@ -35,6 +36,7 @@ public class TestRouteController : RouteViewController {
     }
 
     override fun showRouteIcon(location: ValhallaLocation) {
+        routeLocationMarkerPos = location
     }
 
     override fun centerMapOnCurrentLocation() {


### PR DESCRIPTION
- Adds `onRestoreMapState` method for handling reconfiguring map on orientation changes
- Refactors `routeModeView` configuration into initialization block

Closes #755 