### PR TITLE
Search result restoration

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -422,44 +422,48 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     private fun onActionViewAll() {
-        presenter.onViewAllSearchResults()
+        presenter.onViewAllSearchResultsList()
     }
 
-    override fun showAllSearchResults(features: List<Feature>?) {
+    override fun toggleShowAllSearchResultsList(features: List<Feature>?) {
         if (features == null) {
             return
         }
 
         if (presenter.resultListVisible) {
-            onCloseAllSearchResults()
+            onCloseAllSearchResultsList()
             searchController.enableSearch()
         } else {
-            saveCurrentSearchTerm()
-            presenter.resultListVisible = true
-            optionsMenu?.findItem(R.id.action_view_all)?.setIcon(R.drawable.ic_map)
-
-            val simpleFeatures: ArrayList<AutoCompleteItem> = ArrayList()
-            for (feature in features) {
-                simpleFeatures.add(AutoCompleteItem(SimpleFeature.fromFeature(feature)))
-            }
-            searchController.searchView?.disableAutoKeyboardShow()
-            searchController.searchView?.disableAutoComplete()
-            searchController.searchView?.onActionViewExpanded()
-            searchController.searchView?.setQuery(presenter.currentSearchTerm, false)
-            val autoCompleteAdapter = searchController.autoCompleteListView?.adapter as AutoCompleteAdapter
-            autoCompleteAdapter.clear();
-            autoCompleteAdapter.addAll(simpleFeatures);
-            autoCompleteAdapter.notifyDataSetChanged();
-            searchController.autoCompleteListView?.setOnItemClickListener { parent, view, position, id ->
-                        (findViewById(R.id.search_results) as SearchResultsView).setCurrentItem(position)
-                        onCloseAllSearchResults()
-
-            }
-            searchController.disableSearch()
+            onShowAllSearchResultsList(features)
         }
     }
 
-    override fun onCloseAllSearchResults() {
+    override fun onShowAllSearchResultsList(features: List<Feature>) {
+        saveCurrentSearchTerm()
+        presenter.resultListVisible = true
+        optionsMenu?.findItem(R.id.action_view_all)?.setIcon(R.drawable.ic_map)
+
+        val simpleFeatures: ArrayList<AutoCompleteItem> = ArrayList()
+        for (feature in features) {
+            simpleFeatures.add(AutoCompleteItem(SimpleFeature.fromFeature(feature)))
+        }
+        searchController.searchView?.disableAutoKeyboardShow()
+        searchController.searchView?.disableAutoComplete()
+        searchController.searchView?.onActionViewExpanded()
+        searchController.searchView?.setQuery(presenter.currentSearchTerm, false)
+        val autoCompleteAdapter = searchController.autoCompleteListView?.adapter as AutoCompleteAdapter
+        autoCompleteAdapter.clear()
+        autoCompleteAdapter.addAll(simpleFeatures)
+        autoCompleteAdapter.notifyDataSetChanged()
+        searchController.autoCompleteListView?.setOnItemClickListener { parent, view, position, id ->
+            (findViewById(R.id.search_results) as SearchResultsView).setCurrentItem(position)
+            onCloseAllSearchResultsList()
+
+        }
+        searchController.disableSearch()
+    }
+
+    override fun onCloseAllSearchResultsList() {
         searchController.autoCompleteListView?.onItemClickListener = searchController.searchView?.OnItemClickHandler()?.invoke()
         presenter.resultListVisible = false
         optionsMenu?.findItem(R.id.action_view_all)?.setIcon(R.drawable.ic_list)

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -372,6 +372,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         menuInflater.inflate(R.menu.menu_main, menu)
         optionsMenu = menu
         initSearchView()
+        presenter.onRestoreOptionsMenu()
         return true
     }
 
@@ -480,13 +481,17 @@ class MainActivity : AppCompatActivity(), MainViewController,
         presenter.currentSearchTerm = searchController.searchView?.query.toString()
     }
 
+    override fun setOptionsMenuIconToList() {
+        optionsMenu?.findItem(R.id.action_view_all)?.setIcon(R.drawable.ic_list)
+    }
+
     inner class PeliasCallback : Callback<Result> {
         private val TAG: String = "PeliasCallback"
 
         override fun success(result: Result?, response: Response?) {
             presenter.reverseGeoLngLat = null
             presenter.onSearchResultsAvailable(result)
-            optionsMenu?.findItem(R.id.action_view_all)?.setIcon(R.drawable.ic_list)
+            setOptionsMenuIconToList()
         }
 
         override fun failure(error: RetrofitError?) {
@@ -809,8 +814,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     override fun hideSettingsBtn() {
-        Handler().postDelayed( { optionsMenu?.findItem(R.id.action_settings)?.isVisible = false },
-                100)
+        optionsMenu?.findItem(R.id.action_settings)?.isVisible = false
     }
 
     override fun showSettingsBtn() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -13,7 +13,7 @@ interface MainViewController {
     fun hideDirectionsList()
     fun centerOnCurrentFeature(features: List<Feature>?)
     fun centerOnFeature(features: List<Feature>?, position: Int)
-    fun showAllSearchResults(features: List<Feature>?)
+    fun toggleShowAllSearchResultsList(features: List<Feature>?)
     fun hideSearchResults()
     fun hideReverseGeolocateResult()
     fun showReverseGeocodeFeature(features: List<Feature>?)
@@ -52,7 +52,7 @@ interface MainViewController {
     fun stopSpeaker()
     fun checkPermissionAndEnableLocation()
     fun executeSearch(query: String)
-    fun onCloseAllSearchResults()
+    fun onCloseAllSearchResultsList()
     fun deactivateFindMeTracking()
     fun cancelRouteRequest()
     fun layoutAttributionAboveOptions()
@@ -61,4 +61,5 @@ interface MainViewController {
     fun handleLocationResolutionRequired(status: Status)
     fun setMyLocationEnabled(enabled: Boolean)
     fun setOptionsMenuIconToList()
+    fun onShowAllSearchResultsList(features: List<Feature>)
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -60,4 +60,5 @@ interface MainViewController {
     fun restoreRoutePreviewButtons()
     fun handleLocationResolutionRequired(status: Status)
     fun setMyLocationEnabled(enabled: Boolean)
+    fun setOptionsMenuIconToList()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -36,7 +36,7 @@ interface MainPresenter {
     fun onClickViewList()
     fun onClickStartNavigation()
     fun onQuerySubmit()
-    fun onViewAllSearchResults()
+    fun onViewAllSearchResultsList()
     fun updateLocation()
     fun onBackPressed()
     fun onRestoreViewState()

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -40,6 +40,7 @@ interface MainPresenter {
     fun updateLocation()
     fun onBackPressed()
     fun onRestoreViewState()
+    fun onRestoreOptionsMenu()
     fun onRestoreMapState()
     fun onResume()
     fun onMuteClick()

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -192,6 +192,10 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     mainViewController?.hideSettingsBtn()
     mainViewController?.setOptionsMenuIconToList()
     updateViewAllAction(searchResults)
+    if (resultListVisible && searchResults?.features != null) {
+      val features = searchResults?.features as List<Feature>
+      mainViewController?.onShowAllSearchResultsList(features)
+    }
   }
 
   override fun onRestoreMapState() {
@@ -285,8 +289,8 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     }
   }
 
-  override fun onViewAllSearchResults() {
-    mainViewController?.showAllSearchResults(searchResults?.features)
+  override fun onViewAllSearchResultsList() {
+    mainViewController?.toggleShowAllSearchResultsList(searchResults?.features)
   }
 
   private fun connectAndPostRunnable(run: () -> Unit) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -183,9 +183,23 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   override fun onRestoreOptionsMenu() {
-    if (vsm.viewState == SEARCH_RESULTS) {
-      onRestoreOptionsMenuStateSearchResults()
+    when (vsm.viewState) {
+      DEFAULT -> onRestoreOptionsMenuStateDefault()
+      SEARCH -> onRestoreOptionsMenuStateSearch()
+      SEARCH_RESULTS -> onRestoreOptionsMenuStateSearchResults()
+      ROUTE_PREVIEW -> onRestoreOptionsMenuStateRoutePreview()
+      ROUTE_PREVIEW_LIST -> onRestoreOptionsMenuStateRoutePreviewList()
+      ROUTING -> onRestoreOptionsMenuStateRouting()
+      ROUTE_DIRECTION_LIST -> onRestoreOptionsMenuStateRouteDirectionList()
     }
+  }
+
+  private fun onRestoreOptionsMenuStateDefault() {
+    // Do nothing
+  }
+
+  private fun onRestoreOptionsMenuStateSearch() {
+    // Do nothing
   }
 
   private fun onRestoreOptionsMenuStateSearchResults() {
@@ -196,6 +210,22 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
       val features = searchResults?.features as List<Feature>
       mainViewController?.onShowAllSearchResultsList(features)
     }
+  }
+
+  private fun onRestoreOptionsMenuStateRoutePreview() {
+    mainViewController?.hideSettingsBtn()
+  }
+
+  private fun onRestoreOptionsMenuStateRoutePreviewList() {
+    mainViewController?.hideSettingsBtn()
+  }
+
+  private fun onRestoreOptionsMenuStateRouting() {
+    mainViewController?.hideSettingsBtn()
+  }
+
+  private fun onRestoreOptionsMenuStateRouteDirectionList() {
+    mainViewController?.hideSettingsBtn()
   }
 
   override fun onRestoreMapState() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -141,26 +141,12 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
 
   override fun onRestoreViewState() {
     when (vsm.viewState) {
-      DEFAULT -> onRestoreViewStateDefault()
-      SEARCH -> onRestoreViewStateSearch()
-      SEARCH_RESULTS -> onRestoreViewStateSearchResults()
+      DEFAULT, SEARCH, SEARCH_RESULTS -> {}
       ROUTE_PREVIEW -> onRestoreViewStateRoutePreview()
       ROUTE_PREVIEW_LIST -> onRestoreViewStateRoutePreviewList()
       ROUTING -> onRestoreViewStateRouting()
       ROUTE_DIRECTION_LIST -> onRestoreViewStateRouteDirectionList()
     }
-  }
-
-  private fun onRestoreViewStateDefault() {
-    // Do nothing.
-  }
-
-  private fun onRestoreViewStateSearch() {
-    // Do nothing.
-  }
-
-  private fun onRestoreViewStateSearchResults() {
-    // Do nothing.
   }
 
   private fun onRestoreViewStateRoutePreview() {
@@ -184,22 +170,12 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
 
   override fun onRestoreOptionsMenu() {
     when (vsm.viewState) {
-      DEFAULT -> onRestoreOptionsMenuStateDefault()
-      SEARCH -> onRestoreOptionsMenuStateSearch()
+      DEFAULT, SEARCH -> {}
       SEARCH_RESULTS -> onRestoreOptionsMenuStateSearchResults()
-      ROUTE_PREVIEW -> onRestoreOptionsMenuStateRoutePreview()
-      ROUTE_PREVIEW_LIST -> onRestoreOptionsMenuStateRoutePreviewList()
-      ROUTING -> onRestoreOptionsMenuStateRouting()
-      ROUTE_DIRECTION_LIST -> onRestoreOptionsMenuStateRouteDirectionList()
+      ROUTE_PREVIEW, ROUTE_PREVIEW_LIST, ROUTING, ROUTE_DIRECTION_LIST -> {
+        mainViewController?.hideSettingsBtn()
+      }
     }
-  }
-
-  private fun onRestoreOptionsMenuStateDefault() {
-    // Do nothing
-  }
-
-  private fun onRestoreOptionsMenuStateSearch() {
-    // Do nothing
   }
 
   private fun onRestoreOptionsMenuStateSearchResults() {
@@ -212,40 +188,13 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     }
   }
 
-  private fun onRestoreOptionsMenuStateRoutePreview() {
-    mainViewController?.hideSettingsBtn()
-  }
-
-  private fun onRestoreOptionsMenuStateRoutePreviewList() {
-    mainViewController?.hideSettingsBtn()
-  }
-
-  private fun onRestoreOptionsMenuStateRouting() {
-    mainViewController?.hideSettingsBtn()
-  }
-
-  private fun onRestoreOptionsMenuStateRouteDirectionList() {
-    mainViewController?.hideSettingsBtn()
-  }
-
   override fun onRestoreMapState() {
     when (vsm.viewState) {
-      DEFAULT -> onRestoreMapStateDefault()
-      SEARCH -> onRestoreMapStateSearch()
+      DEFAULT, SEARCH -> {}
       SEARCH_RESULTS -> onRestoreMapStateSearchResults()
-      ROUTE_PREVIEW -> onRestoreMapStateRoutePreview()
-      ROUTE_PREVIEW_LIST -> onRestoreMapStateRoutePreviewList()
-      ROUTING -> onRestoreMapStateRouting()
-      ROUTE_DIRECTION_LIST -> onRestoreMapStateRouteDirectionList()
+      ROUTE_PREVIEW, ROUTE_PREVIEW_LIST -> adjustLayoutAndRoute()
+      ROUTING, ROUTE_DIRECTION_LIST -> mainViewController?.resumeRoutingModeForMap()
     }
-  }
-
-  private fun onRestoreMapStateDefault() {
-    // Do nothing
-  }
-
-  private fun onRestoreMapStateSearch() {
-    // Do nothing
   }
 
   private fun onRestoreMapStateSearchResults() {
@@ -257,22 +206,6 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
         mainViewController?.centerOnCurrentFeature(searchResults?.features)
       }
     }
-  }
-
-  private fun onRestoreMapStateRoutePreview() {
-    adjustLayoutAndRoute()
-  }
-
-  private fun onRestoreMapStateRoutePreviewList() {
-    adjustLayoutAndRoute()
-  }
-
-  private fun onRestoreMapStateRouting() {
-    mainViewController?.resumeRoutingModeForMap()
-  }
-
-  private fun onRestoreMapStateRouteDirectionList() {
-    mainViewController?.resumeRoutingModeForMap()
   }
 
   private fun adjustLayoutAndRoute() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -89,6 +89,10 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     mainViewController?.showSearchResults(result?.features)
     mainViewController?.hideProgress()
     mainViewController?.deactivateFindMeTracking()
+    updateViewAllAction(result)
+  }
+
+  private fun updateViewAllAction(result: Result?) {
     val featureCount = result?.features?.size
     if (featureCount != null && featureCount > 1) {
       mainViewController?.showActionViewAll()
@@ -156,7 +160,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   private fun onRestoreViewStateSearchResults() {
-    mainViewController?.hideSettingsBtn()
+    // Do nothing.
   }
 
   private fun onRestoreViewStateRoutePreview() {
@@ -178,6 +182,18 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     routeViewController?.showRouteDirectionList()
   }
 
+  override fun onRestoreOptionsMenu() {
+    if (vsm.viewState == SEARCH_RESULTS) {
+      onRestoreOptionsMenuStateSearchResults()
+    }
+  }
+
+  private fun onRestoreOptionsMenuStateSearchResults() {
+    mainViewController?.hideSettingsBtn()
+    mainViewController?.setOptionsMenuIconToList()
+    updateViewAllAction(searchResults)
+  }
+
   override fun onRestoreMapState() {
     when (vsm.viewState) {
       DEFAULT -> onRestoreMapStateDefault()
@@ -195,7 +211,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   private fun onRestoreMapStateSearch() {
-
+    // Do nothing
   }
 
   private fun onRestoreMapStateSearchResults() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsView.kt
@@ -78,7 +78,7 @@ open class SearchResultsView(context: Context, attrs: AttributeSet)
             if (b) {
                 mainController?.expandSearchView()
             } else if (presenter.resultListVisible) {
-                mainController?.onCloseAllSearchResults()
+                mainController?.onCloseAllSearchResultsList()
                 enableSearch()
             } else {
                 searchView.setQuery(presenter.currentSearchTerm, false)

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsView.kt
@@ -54,6 +54,7 @@ open class SearchResultsView(context: Context, attrs: AttributeSet)
             callback: MainActivity.PeliasCallback) {
 
         this.searchView = searchView
+        this.autoCompleteListView = autoCompleteListView
 
         searchView.setRecentSearchIconResourceId(R.drawable.ic_recent)
         searchView.setAutoCompleteIconResourceId(R.drawable.ic_pin_c)

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsView.kt
@@ -58,7 +58,6 @@ open class SearchResultsView(context: Context, attrs: AttributeSet)
 
         searchView.setRecentSearchIconResourceId(R.drawable.ic_recent)
         searchView.setAutoCompleteIconResourceId(R.drawable.ic_pin_c)
-        initAutoCompleteAdapter()
         autoCompleteListView.adapter = initAutoCompleteAdapter()
         mapzenSearch.setLocationProvider(locationProvider)
         searchView.setAutoCompleteListView(autoCompleteListView)

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -41,6 +41,7 @@ class TestMainController : MainViewController {
     var isRouting = false
     var isRouteBtnVisibleAndMapCentered = false
     var isOptionsMenuIconList = false
+    var isShowingSearchResultsList = false
 
     var settingsApiTriggered: Boolean = false
 
@@ -84,7 +85,7 @@ class TestMainController : MainViewController {
         isViewAllVisible = false
     }
 
-    override fun showAllSearchResults(features: List<Feature>?) {
+    override fun toggleShowAllSearchResultsList(features: List<Feature>?) {
     }
 
     override fun collapseSearchView() {
@@ -242,7 +243,7 @@ class TestMainController : MainViewController {
     override fun restoreRoutePreviewButtons() {
     }
 
-    override fun onCloseAllSearchResults() {
+    override fun onCloseAllSearchResultsList() {
     }
 
     override fun handleLocationResolutionRequired(status: Status) {
@@ -255,5 +256,9 @@ class TestMainController : MainViewController {
 
     override fun setOptionsMenuIconToList() {
         isOptionsMenuIconList = true
+    }
+
+    override fun onShowAllSearchResultsList(features: List<Feature>) {
+        isShowingSearchResultsList = true
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -40,6 +40,7 @@ class TestMainController : MainViewController {
     var isFindMeAboveOptions = false
     var isRouting = false
     var isRouteBtnVisibleAndMapCentered = false
+    var isOptionsMenuIconList = false
 
     var settingsApiTriggered: Boolean = false
 
@@ -250,5 +251,9 @@ class TestMainController : MainViewController {
 
     override fun setMyLocationEnabled(enabled: Boolean) {
         isCurrentLocationEnabled = enabled
+    }
+
+    override fun setOptionsMenuIconToList() {
+        isOptionsMenuIconList = true
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -124,6 +124,20 @@ class MainPresenterTest {
         assertThat(mainController.isPlaceResultOverridden).isTrue()
     }
 
+    @Test fun onRestoreOptionsMenuState_shouldRestoreSettingsBtnAndViewAllForSearchResults() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        features.add(Feature())
+        features.add(Feature())
+        result.features = features
+        presenter.onSearchResultsAvailable(result)
+
+        presenter.onRestoreOptionsMenu()
+        assertThat(mainController.isSettingsVisible).isFalse()
+        assertThat(mainController.isOptionsMenuIconList).isTrue()
+        assertThat(mainController.isViewAllVisible).isTrue()
+    }
+
     @Test fun onRestoreMapState_shouldRestorePreviousSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()
@@ -176,15 +190,6 @@ class MainPresenterTest {
         presenter.onClickStartNavigation()
         presenter.onRestoreMapState()
         assertThat(mainController.isRouteBtnVisibleAndMapCentered).isTrue()
-    }
-
-    @Test fun onRestoreViewState_shouldHideSettingsButtonWhileShowingSearchResults() {
-        val result = Result()
-        result.features = ArrayList<Feature>()
-        presenter.onSearchResultsAvailable(result)
-        mainController.isSettingsVisible = true
-        presenter.onRestoreViewState()
-        assertThat(mainController.isSettingsVisible).isFalse()
     }
 
     @Test fun onRestoreViewState_shouldRestoreRoutePreview() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -124,7 +124,7 @@ class MainPresenterTest {
         assertThat(mainController.isPlaceResultOverridden).isTrue()
     }
 
-    @Test fun onRestoreOptionsMenuState_shouldRestoreSettingsBtnAndViewAllForSearchResults() {
+    @Test fun onRestoreOptionsMenu_shouldRestoreSettingsBtnAndViewAllForSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()
         features.add(Feature())
@@ -138,7 +138,7 @@ class MainPresenterTest {
         assertThat(mainController.isViewAllVisible).isTrue()
     }
 
-    @Test fun onRestoreOptionsMenuState_shouldShowListForSearchListVisible() {
+    @Test fun onRestoreOptionsMenu_shouldShowListForSearchListVisible() {
         val result = Result()
         val features = ArrayList<Feature>()
         features.add(Feature())
@@ -148,6 +148,30 @@ class MainPresenterTest {
         presenter.resultListVisible = true
         presenter.onRestoreOptionsMenu()
         assertThat(mainController.isShowingSearchResultsList).isTrue()
+    }
+
+    @Test fun onRestoreOptionsMenu_shouldHideSettingsBtnRoutePreview() {
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onRestoreOptionsMenu()
+        assertThat(mainController.isSettingsVisible).isFalse()
+    }
+
+    @Test fun onRestoreOptionsMenu_shouldHideSettingsBtnRouteList() {
+        presenter.onClickViewList()
+        presenter.onRestoreOptionsMenu()
+        assertThat(mainController.isSettingsVisible).isFalse()
+    }
+
+    @Test fun onRestoreOptionsMenu_shouldHideSettingsBtnRouting() {
+        presenter.onClickStartNavigation()
+        presenter.onRestoreOptionsMenu()
+        assertThat(mainController.isSettingsVisible).isFalse()
+    }
+
+    @Test fun onRestoreOptionsMenu_shouldHideSettingsBtnRouteDirectionsList() {
+        vsm.viewState = ROUTE_DIRECTION_LIST
+        presenter.onRestoreOptionsMenu()
+        assertThat(mainController.isSettingsVisible).isFalse()
     }
 
     @Test fun onRestoreMapState_shouldRestorePreviousSearchResults() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -138,6 +138,18 @@ class MainPresenterTest {
         assertThat(mainController.isViewAllVisible).isTrue()
     }
 
+    @Test fun onRestoreOptionsMenuState_shouldShowListForSearchListVisible() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        features.add(Feature())
+        features.add(Feature())
+        result.features = features
+        presenter.onSearchResultsAvailable(result)
+        presenter.resultListVisible = true
+        presenter.onRestoreOptionsMenu()
+        assertThat(mainController.isShowingSearchResultsList).isTrue()
+    }
+
     @Test fun onRestoreMapState_shouldRestorePreviousSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()


### PR DESCRIPTION
- Updates how we handle restoring the options menu so that we don't try to call methods on it before it has been created
- Fixes bug which prevented options menu buttons from being restored on device rotation when viewing search results
- Fixes bug which didnt restore search results list view on device orientation
- Fixes bug which caused the settings button to show (upon back pressing to search results) when rotating the device while viewing the route preview, route preview directions, route, and route directions screens

Closes #759 