### PR TITLE
Dont show action bar on rotation in route preview mode

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -826,7 +826,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         optionsMenu?.findItem(R.id.action_settings)?.setVisible(true)
     }
 
-    override fun showRoutePreview(destination: SimpleFeature) {
+    override fun showRoutePreviewDestination(destination: SimpleFeature) {
         routePreviewView.destination = destination
     }
 
@@ -838,17 +838,26 @@ class MainActivity : AppCompatActivity(), MainViewController,
         routeModeView.clearRoute()
     }
 
+    override fun hideActionBar() {
+        supportActionBar?.hide()
+    }
+
+    override fun showRoutePreviewView() {
+        routePreviewView.visibility = View.VISIBLE
+    }
+
+    override fun showRoutePreviewDistanceTimeLayout() {
+        routePreviewDistanceTimeLayout.visibility = View.VISIBLE
+    }
+
     private fun onRouteSuccess(route: Route) {
         routeManager.route = route
         routePreviewView.route = route
-        runOnUiThread ({
-            if (routeModeView.visibility != View.VISIBLE) {
-                supportActionBar?.hide()
-                routePreviewView.visibility = View.VISIBLE
-                routePreviewDistanceTimeLayout.visibility = View.VISIBLE
-                zoomToShowRoute(route.getGeometry().toTypedArray())
-            }
-        })
+        supportActionBar?.hide()
+        routePreviewView.visibility = View.VISIBLE
+        routePreviewDistanceTimeLayout.visibility = View.VISIBLE
+        zoomToShowRoute(route.getGeometry().toTypedArray())
+
         updateRoutePreview()
         routeModeView.drawRoute(route, routeManager.type)
         routePreviewView.enableStartNavigation(routeManager.type, routeManager.reverse)

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.controller
 
 import com.mapzen.android.lost.api.Status
+import com.mapzen.model.ValhallaLocation
 import com.mapzen.pelias.SimpleFeature
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.tangram.LngLat
@@ -65,4 +66,7 @@ interface MainViewController {
     fun hideActionBar()
     fun showRoutePreviewView()
     fun showRoutePreviewDistanceTimeLayout()
+    fun setRoutePreviewViewRoute(route: Route)
+    fun showRoutePinsOnMap(locations: Array<ValhallaLocation>)
+    fun updateRoutePreviewStartNavigation()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -25,7 +25,7 @@ interface MainViewController {
     fun collapseSearchView()
     fun expandSearchView()
     fun clearQuery()
-    fun showRoutePreview(destination: SimpleFeature)
+    fun showRoutePreviewDestination(destination: SimpleFeature)
     fun route()
     fun hideRoutePreview()
     fun hideRoutingMode()
@@ -62,4 +62,7 @@ interface MainViewController {
     fun setMyLocationEnabled(enabled: Boolean)
     fun setOptionsMenuIconToList()
     fun onShowAllSearchResultsList(features: List<Feature>)
+    fun hideActionBar()
+    fun showRoutePreviewView()
+    fun showRoutePreviewDistanceTimeLayout()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -7,6 +7,7 @@ import com.mapzen.pelias.PeliasLocationProvider
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.gson.Result
 import com.mapzen.tangram.LngLat
+import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.RouteCallback
 
 interface MainPresenter {
@@ -58,4 +59,5 @@ interface MainPresenter {
     fun onFeaturePicked(properties: Map<String, String>, poiPoint: FloatArray)
     fun checkPermissionAndEnableLocation()
     fun onClickFindMe()
+    fun onRouteSuccess(route: Route)
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -471,10 +471,8 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   override fun success(route: Route) {
-    mainViewController?.hideProgress()
-    routeManager.route = route
+    handleRouteRetrieved(route)
     generateRoutingMode(false)
-    mainViewController?.drawRoute(route)
     waitingForRoute = false
   }
 
@@ -593,15 +591,13 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   override fun onRouteSuccess(route: Route) {
-    routeManager.route = route
+    handleRouteRetrieved(route)
     mainViewController?.setRoutePreviewViewRoute(route)
     mainViewController?.hideActionBar()
     mainViewController?.showRoutePreviewView()
     mainViewController?.showRoutePreviewDistanceTimeLayout()
     mainViewController?.showRoutePinsOnMap(route.getGeometry().toTypedArray())
-    mainViewController?.drawRoute(route)
     mainViewController?.updateRoutePreviewStartNavigation()
-    mainViewController?.hideProgress()
   }
 
   private fun showRoutePreview(location: ValhallaLocation, feature: Feature) {
@@ -685,5 +681,11 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
       LocationServices.FusedLocationApi?.setMockMode(client, true)
       LocationServices.FusedLocationApi?.setMockLocation(client, settings.mockLocation)
     }
+  }
+
+  private fun handleRouteRetrieved(route: Route) {
+    routeManager.route = route
+    mainViewController?.drawRoute(route)
+    mainViewController?.hideProgress()
   }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -150,6 +150,8 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   private fun onRestoreViewStateRoutePreview() {
+    mainViewController?.showRoutePreviewView()
+    mainViewController?.showRoutePreviewDistanceTimeLayout()
     generateRoutePreview(false)
     mainViewController?.restoreRoutePreviewButtons()
   }
@@ -172,7 +174,11 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     when (vsm.viewState) {
       DEFAULT, SEARCH -> {}
       SEARCH_RESULTS -> onRestoreOptionsMenuStateSearchResults()
-      ROUTE_PREVIEW, ROUTE_PREVIEW_LIST, ROUTING, ROUTE_DIRECTION_LIST -> {
+      ROUTE_PREVIEW -> {
+        mainViewController?.hideActionBar()
+        mainViewController?.hideSettingsBtn()
+      }
+      ROUTE_PREVIEW_LIST, ROUTING, ROUTE_DIRECTION_LIST -> {
         mainViewController?.hideSettingsBtn()
       }
     }
@@ -606,11 +612,11 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
 
     val confidenceHandler = ConfidenceHandler(this)
     if (!confidenceHandler.useRawLatLng(feature.properties.confidence)) {
-      mainViewController?.showRoutePreview(SimpleFeature.fromFeature(feature))
+      mainViewController?.showRoutePreviewDestination(SimpleFeature.fromFeature(feature))
       routeManager.destination = feature
     } else {
       val rawFeature = generateRawFeature()
-      mainViewController?.showRoutePreview(SimpleFeature.fromFeature(rawFeature))
+      mainViewController?.showRoutePreviewDestination(SimpleFeature.fromFeature(rawFeature))
       routeManager.destination = rawFeature
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -592,6 +592,18 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     routeManager.fetchRoute(callback)
   }
 
+  override fun onRouteSuccess(route: Route) {
+    routeManager.route = route
+    mainViewController?.setRoutePreviewViewRoute(route)
+    mainViewController?.hideActionBar()
+    mainViewController?.showRoutePreviewView()
+    mainViewController?.showRoutePreviewDistanceTimeLayout()
+    mainViewController?.showRoutePinsOnMap(route.getGeometry().toTypedArray())
+    mainViewController?.drawRoute(route)
+    mainViewController?.updateRoutePreviewStartNavigation()
+    mainViewController?.hideProgress()
+  }
+
   private fun showRoutePreview(location: ValhallaLocation, feature: Feature) {
     showRoutePreview(location, feature, true)
   }

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -1,6 +1,7 @@
 package com.mapzen.erasermap.controller
 
 import com.mapzen.android.lost.api.Status
+import com.mapzen.model.ValhallaLocation
 import com.mapzen.pelias.SimpleFeature
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.tangram.LngLat
@@ -46,6 +47,8 @@ class TestMainController : MainViewController {
     var isActionBarHidden = false
     var isRoutePreviewVisible: Boolean = false
     var isRoutePreviewDistanceTieVisible = false
+    var routePreviewRoute: Route? = null
+    var routePinLocations: Array<ValhallaLocation>? = null
 
     override fun showSearchResults(features: List<Feature>?) {
         searchResults = features
@@ -274,5 +277,17 @@ class TestMainController : MainViewController {
 
     override fun showRoutePreviewDistanceTimeLayout() {
         isRoutePreviewDistanceTieVisible = true
+    }
+
+    override fun setRoutePreviewViewRoute(route: Route) {
+        routePreviewRoute = route
+    }
+
+    override fun showRoutePinsOnMap(locations: Array<ValhallaLocation>) {
+        routePinLocations = locations
+    }
+
+    override fun updateRoutePreviewStartNavigation() {
+
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -23,7 +23,7 @@ class TestMainController : MainViewController {
     var isProgressVisible: Boolean = false
     var isViewAllVisible: Boolean = false
     var isSearchVisible: Boolean = false
-    var isRoutePreviewVisible: Boolean = false
+    var isRoutePreviewDestinationVisible: Boolean = false
     var isDirectionListVisible: Boolean = false
     var isRoutingModeVisible: Boolean = false
     var isCenteredOnCurrentFeature: Boolean = false
@@ -42,8 +42,10 @@ class TestMainController : MainViewController {
     var isRouteBtnVisibleAndMapCentered = false
     var isOptionsMenuIconList = false
     var isShowingSearchResultsList = false
-
     var settingsApiTriggered: Boolean = false
+    var isActionBarHidden = false
+    var isRoutePreviewVisible: Boolean = false
+    var isRoutePreviewDistanceTieVisible = false
 
     override fun showSearchResults(features: List<Feature>?) {
         searchResults = features
@@ -99,8 +101,8 @@ class TestMainController : MainViewController {
         queryText = ""
     }
 
-    override fun showRoutePreview(destination: SimpleFeature) {
-        isRoutePreviewVisible = true
+    override fun showRoutePreviewDestination(destination: SimpleFeature) {
+        isRoutePreviewDestinationVisible = true
     }
 
     override fun route() {
@@ -260,5 +262,17 @@ class TestMainController : MainViewController {
 
     override fun onShowAllSearchResultsList(features: List<Feature>) {
         isShowingSearchResultsList = true
+    }
+
+    override fun hideActionBar() {
+        isActionBarHidden = true
+    }
+
+    override fun showRoutePreviewView() {
+        isRoutePreviewVisible = true
+    }
+
+    override fun showRoutePreviewDistanceTimeLayout() {
+        isRoutePreviewDistanceTieVisible = true
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -3,6 +3,7 @@ package com.mapzen.erasermap.presenter
 import com.mapzen.android.lost.api.Status
 import com.mapzen.erasermap.controller.TestMainController
 import com.mapzen.erasermap.dummy.TestHelper
+import com.mapzen.erasermap.dummy.TestHelper.getFixture
 import com.mapzen.erasermap.dummy.TestHelper.getTestAndroidLocation
 import com.mapzen.erasermap.dummy.TestHelper.getTestFeature
 import com.mapzen.erasermap.dummy.TestHelper.getTestLocation
@@ -586,7 +587,7 @@ class MainPresenterTest {
         assertThat(mainController.isProgressVisible).isFalse()
     }
 
-    @Test fun onRouteSuccess_shouldHideProgress() {
+    @Test fun success_shouldHideProgress() {
         mainController.isProgressVisible = true
         presenter.success(Route(JSONObject()))
         assertThat(mainController.isProgressVisible).isFalse()
@@ -723,6 +724,64 @@ class MainPresenterTest {
         mainController.routeRequestCanceled = false
         presenter.onRouteRequest(TestRouteCallback())
         assertThat(mainController.routeRequestCanceled).isTrue()
+    }
+
+    @Test fun onRouteSuccess_shouldSetRouteManagerRoute() {
+        routeManager.route = null
+        val route = Route(JSONObject())
+        presenter.onRouteSuccess(route)
+        assertThat(routeManager.route as Route).isEqualTo(route)
+    }
+
+    @Test fun onRouteSuccess_shouldSetRoutePreviewRoute() {
+        mainController.routePreviewRoute = null
+        val route = Route(JSONObject())
+        presenter.onRouteSuccess(route)
+        assertThat(mainController.routePreviewRoute as Route).isEqualTo(route)
+    }
+
+    @Test fun onRouteSuccess_shouldHideActionBar() {
+        mainController.isActionBarHidden = false
+        val route = Route(JSONObject())
+        presenter.onRouteSuccess(route)
+        assertThat(mainController.isActionBarHidden).isTrue()
+    }
+
+    @Test fun onRouteSuccess_shouldShowRoutePreview() {
+        mainController.isRoutePreviewVisible = false
+        val route = Route(JSONObject())
+        presenter.onRouteSuccess(route)
+        assertThat(mainController.isRoutePreviewVisible).isTrue()
+    }
+
+    @Test fun onRouteSuccess_shouldShowRoutePreviewDistanceTimeLayout() {
+        mainController.isRoutePreviewDistanceTieVisible = false
+        val route = Route(JSONObject())
+        presenter.onRouteSuccess(route)
+        assertThat(mainController.isRoutePreviewDistanceTieVisible).isTrue()
+    }
+
+    @Test fun onRouteSuccess_shouldShowRoutePreviewPins() {
+        mainController.routePinLocations = null
+        val routeJson = getFixture("valhalla_route")
+        val route = Route(routeJson)
+        presenter.onRouteSuccess(route)
+        assertThat(mainController.routePinLocations?.get(0)?.latitude)?.isEqualTo(52.503028)
+        assertThat(mainController.routePinLocations?.get(0)?.longitude)?.isEqualTo(13.42053)
+    }
+
+    @Test fun onRouteSuccess_shouldDrawRouteOnRoutePreview() {
+        mainController.routeLine = null
+        val route = Route(JSONObject())
+        presenter.onRouteSuccess(route)
+        assertThat(mainController.routeLine as Route).isEqualTo(route)
+    }
+
+    @Test fun onRouteSuccess_shouldHideProgress() {
+        mainController.isProgressVisible = true
+        val route = Route(JSONObject())
+        presenter.onRouteSuccess(route)
+        assertThat(mainController.isProgressVisible).isFalse()
     }
 
     @Test fun onRouteRequest_shouldFetchRoute() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -156,6 +156,13 @@ class MainPresenterTest {
         assertThat(mainController.isSettingsVisible).isFalse()
     }
 
+    @Test fun onRestoreOptionsMenu_shouldHideActionBar() {
+        mainController.isActionBarHidden = false
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onRestoreOptionsMenu()
+        assertThat(mainController.isActionBarHidden).isTrue()
+    }
+
     @Test fun onRestoreOptionsMenu_shouldHideSettingsBtnRouteList() {
         presenter.onClickViewList()
         presenter.onRestoreOptionsMenu()
@@ -228,12 +235,25 @@ class MainPresenterTest {
         assertThat(mainController.isRouteBtnVisibleAndMapCentered).isTrue()
     }
 
-    @Test fun onRestoreViewState_shouldRestoreRoutePreview() {
+    @Test fun onRestoreViewState_shouldRestoreRoutePreviewDestination() {
+        mainController.isRoutePreviewDestinationVisible = false
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
-        val newController = TestMainController()
-        presenter.mainViewController = newController
         presenter.onRestoreViewState()
-        assertThat(newController.isRoutePreviewVisible).isTrue()
+        assertThat(mainController.isRoutePreviewDestinationVisible).isTrue()
+    }
+
+    @Test fun onRestoreViewState_shouldShowRoutePreview() {
+        mainController.isRoutePreviewVisible = false
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onRestoreViewState()
+        assertThat(mainController.isRoutePreviewVisible).isTrue()
+    }
+
+    @Test fun onRestoreViewState_shouldShowRoutePreviewDistanceTimeLayout() {
+        mainController.isRoutePreviewDistanceTieVisible = false
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onRestoreViewState()
+        assertThat(mainController.isRoutePreviewDistanceTieVisible).isTrue()
     }
 
     @Test fun onRestoreViewState_shouldRestoreRoutePreviewList() {
@@ -351,10 +371,10 @@ class MainPresenterTest {
         assertThat(mainController.searchResults).isNull()
     }
 
-    @Test fun onRoutePreviewEvent_shouldShowRoutePreview() {
-        mainController.isRoutePreviewVisible = false
+    @Test fun onRoutePreviewEvent_shouldShowRoutePreviewDestination() {
+        mainController.isRoutePreviewDestinationVisible = false
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
-        assertThat(mainController.isRoutePreviewVisible).isTrue()
+        assertThat(mainController.isRoutePreviewDestinationVisible).isTrue()
     }
 
     @Test fun onRoutePreviewEvent_shouldDisableReverseGeocode() {


### PR DESCRIPTION
This PR prevents the action bar (search bar) from showing when the device is rotated while in route preview mode by hiding it as soon as the action bar is created (previously it wasnt hidden until the route was successfully fetched from the server). It also extracts out some logic for handling what happens when a route is successfully fetched and moves it into the `MainPresenter`/adds test coverage.

Closes #765 