### PR TITLE
Always use feature display helper class to display feature name

### DIFF
--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -5,6 +5,7 @@ import com.mapzen.android.search.MapzenSearch;
 import com.mapzen.erasermap.model.AndroidAppSettings;
 import com.mapzen.erasermap.model.ApiKeys;
 import com.mapzen.erasermap.model.AppSettings;
+import com.mapzen.erasermap.model.ConfidenceHandler;
 import com.mapzen.erasermap.model.Http;
 import com.mapzen.erasermap.model.IntentQueryParser;
 import com.mapzen.erasermap.model.LocationConverter;
@@ -22,6 +23,7 @@ import com.mapzen.erasermap.model.ValhallaRouterFactory;
 import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
 import com.mapzen.erasermap.presenter.ViewStateManager;
+import com.mapzen.erasermap.util.FeatureDisplayHelper;
 import com.mapzen.erasermap.util.IntentFactory;
 import com.mapzen.erasermap.view.Speaker;
 import com.mapzen.erasermap.view.SpeakerboxSpeaker;
@@ -143,5 +145,14 @@ public class AndroidModule {
 
     @Provides @Singleton LocationSettingsChecker provideLocationSettingsChecker() {
         return new LostSettingsChecker();
+    }
+
+    @Provides @Singleton ConfidenceHandler provideConfidenceHandler(MainPresenter mainPresenter) {
+        return new ConfidenceHandler(mainPresenter);
+    }
+
+    @Provides @Singleton FeatureDisplayHelper provideDisplayHelper(
+        ConfidenceHandler confidenceHandler) {
+        return new FeatureDisplayHelper(application, confidenceHandler);
     }
 }

--- a/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
+++ b/app/src/main/java/com/mapzen/erasermap/EraserMapApplication.java
@@ -5,6 +5,7 @@ import com.mapzen.erasermap.receiver.MockLocationReceiver;
 import com.mapzen.erasermap.view.DistanceView;
 import com.mapzen.erasermap.view.InitActivity;
 import com.mapzen.erasermap.view.RouteModeView;
+import com.mapzen.erasermap.view.RoutePreviewView;
 import com.mapzen.erasermap.view.SearchResultsAdapter;
 import com.mapzen.erasermap.view.SearchResultsView;
 import com.mapzen.erasermap.view.SettingsActivity;
@@ -31,6 +32,7 @@ public class EraserMapApplication extends Application {
         void inject(MockLocationReceiver receiver);
         void inject(ViewAboutPreference viewAboutPreference);
         void inject(SearchResultsView searchResultsView);
+        void inject(RoutePreviewView routePreviewView);
     }
 
     private ApplicationComponent component;

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -41,6 +41,7 @@ import com.mapzen.erasermap.model.TileHttpHandler
 import com.mapzen.erasermap.presenter.MainPresenter
 import com.mapzen.erasermap.util.AxisAlignedBoundingBox
 import com.mapzen.erasermap.util.AxisAlignedBoundingBox.PointD
+import com.mapzen.erasermap.util.FeatureDisplayHelper
 import com.mapzen.erasermap.util.NotificationBroadcastReceiver
 import com.mapzen.erasermap.util.NotificationCreator
 import com.mapzen.erasermap.view.CompassView
@@ -95,6 +96,8 @@ class MainActivity : AppCompatActivity(), MainViewController,
     @Inject lateinit var permissionManager: PermissionManager
     @Inject lateinit var apiKeys: ApiKeys
     @Inject lateinit var lostClientManager: LostClientManager
+    @Inject lateinit var confidenceHandler: ConfidenceHandler
+    @Inject lateinit var displayHelper: FeatureDisplayHelper
 
     lateinit var app: EraserMapApplication
     var mapzenMap : MapzenMap? = null
@@ -104,7 +107,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     var poiTapName: String? = null
     var voiceNavigationController: VoiceNavigationController? = null
     var notificationCreator: NotificationCreator? = null
-    lateinit var confidenceHandler: ConfidenceHandler
+
     var enableLocation: Boolean = false
 
     // activity_main
@@ -147,7 +150,6 @@ class MainActivity : AppCompatActivity(), MainViewController,
         setContentView(R.layout.activity_main)
         presenter.mainViewController = this
         initVoiceNavigationController() // must initialize this before calling initMute
-        initConfidenceHandler()
         initNotificationCreator()
         presenter.onRestoreViewState()
         initMapzenMap()
@@ -336,10 +338,6 @@ class MainActivity : AppCompatActivity(), MainViewController,
 
     private fun initNotificationCreator() {
         notificationCreator = NotificationCreator(this)
-    }
-
-    private fun initConfidenceHandler() {
-        confidenceHandler = ConfidenceHandler(presenter)
     }
 
     override fun centerMapOnLocation(lngLat: LngLat, zoom: Float) {
@@ -547,7 +545,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     private fun showSearchResultsView(features: List<Feature>) {
-        searchController.setSearchResultsAdapter(SearchResultsAdapter(this, features, confidenceHandler,
+        searchController.setSearchResultsAdapter(SearchResultsAdapter(this, features, displayHelper,
                 permissionManager))
         searchController.showSearchResults()
         searchController.onSearchResultsSelectedListener = this
@@ -705,7 +703,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
 
     override fun showPlaceSearchFeature(features: List<Feature>) {
         searchController.setSearchResultsAdapter(SearchResultsAdapter(this, features.subList(0, 1),
-                confidenceHandler, permissionManager))
+                displayHelper, permissionManager))
         searchController.showSearchResults()
         searchController.onSearchResultsSelectedListener = this
     }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
@@ -4,7 +4,7 @@ import com.mapzen.erasermap.presenter.MainPresenter
 
 class ConfidenceHandler(val presenter: MainPresenter) {
 
-    var longPressed = false;
+    var longPressed = false
 
     companion object {
         const val CONFIDENCE_THRESHOLD = 0.8
@@ -13,7 +13,7 @@ class ConfidenceHandler(val presenter: MainPresenter) {
 
     fun useRawLatLng(confidence: Double): Boolean {
         if (confidence == CONFIDENCE_MISSING || !longPressed) {
-            return false;
+            return false
         }
         return confidence < CONFIDENCE_THRESHOLD
                 && presenter.reverseGeoLngLat != null

--- a/app/src/main/kotlin/com/mapzen/erasermap/util/FeatureDisplayHelper.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/util/FeatureDisplayHelper.kt
@@ -1,0 +1,21 @@
+package com.mapzen.erasermap.util
+
+import android.content.Context
+import com.mapzen.erasermap.R
+import com.mapzen.erasermap.model.ConfidenceHandler
+import com.mapzen.pelias.SimpleFeature
+
+/**
+ * Helper class used to display the name of a feature in the route preview view and in the
+ * reverse geocode info view.
+ */
+class FeatureDisplayHelper(val context: Context, val confidenceHandler: ConfidenceHandler) {
+
+  fun getDisplayName(feature: SimpleFeature): String {
+    if (confidenceHandler.useRawLatLng(feature.confidence()) || feature.name().isBlank()) {
+      return context.getString(R.string.dropped_pin)
+    } else {
+      return feature.name()
+    }
+  }
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RoutePreviewView.kt
@@ -15,18 +15,24 @@ import android.widget.Button
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
+import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
 import com.mapzen.erasermap.controller.MainActivity
 import com.mapzen.erasermap.model.MultiModalHelper
 import com.mapzen.erasermap.model.RouteManager
+import com.mapzen.erasermap.util.FeatureDisplayHelper
 import com.mapzen.pelias.SimpleFeature
 import com.mapzen.valhalla.Instruction
 import com.mapzen.valhalla.Route
 import com.mapzen.valhalla.Router
 import java.util.ArrayList
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
 class RoutePreviewView : RelativeLayout {
+
+    @Inject lateinit var displayHelper: FeatureDisplayHelper
+
     val startView: TextView by lazy { findViewById(R.id.starting_point) as TextView }
     val destinationView: TextView by lazy { findViewById(R.id.destination) as TextView }
     val distancePreview: DistanceView by lazy { findViewById(R.id.distance_preview) as DistanceView }
@@ -50,11 +56,17 @@ class RoutePreviewView : RelativeLayout {
         set (value) {
             field = value
             if (value) {
-                startView.text = destination?.name()
+                if (destination != null) {
+                    startView.text = displayHelper.getDisplayName(
+                        destination as SimpleFeature)
+                }
                 destinationView.setText(R.string.current_location)
             } else {
                 startView.setText(R.string.current_location)
-                destinationView.text = destination?.name()
+                if (destination != null) {
+                    destinationView.text = displayHelper.getDisplayName(
+                        destination as SimpleFeature)
+                }
             }
         }
 
@@ -62,7 +74,9 @@ class RoutePreviewView : RelativeLayout {
         set (value) {
             field = value
             startView.setText(R.string.current_location)
-            destinationView.text = value?.name()
+            if (value != null) {
+                destinationView.text = displayHelper.getDisplayName(value)
+            }
         }
 
     var route: Route? = null
@@ -91,6 +105,7 @@ class RoutePreviewView : RelativeLayout {
     private fun init() {
         (context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater)
                 .inflate(R.layout.view_route_preview, this, true)
+        (context.applicationContext as EraserMapApplication).component().inject(this)
     }
 
     fun disableStartNavigation() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsAdapter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/SearchResultsAdapter.kt
@@ -8,16 +8,16 @@ import android.widget.ImageButton
 import android.widget.TextView
 import com.mapzen.erasermap.EraserMapApplication
 import com.mapzen.erasermap.R
-import com.mapzen.erasermap.model.ConfidenceHandler
 import com.mapzen.erasermap.model.PermissionManager
 import com.mapzen.erasermap.model.event.RoutePreviewEvent
+import com.mapzen.erasermap.util.FeatureDisplayHelper
 import com.mapzen.pelias.SimpleFeature
 import com.mapzen.pelias.gson.Feature
 import com.squareup.otto.Bus
 import javax.inject.Inject
 
 class SearchResultsAdapter(val context: Context, val features: List<Feature>,
-                            val confidenceHandler: ConfidenceHandler,
+                            val displayHelper: FeatureDisplayHelper,
                            val permissionManager: PermissionManager)
         : PagerAdapter() {
 
@@ -34,12 +34,7 @@ class SearchResultsAdapter(val context: Context, val features: List<Feature>,
         val title = view.findViewById(R.id.title) as TextView
         val address = view.findViewById(R.id.address) as TextView
         val start = view.findViewById(R.id.preview) as ImageButton
-        if (confidenceHandler.useRawLatLng(simpleFeature.confidence())
-            || simpleFeature.name().isBlank()) {
-            title.text = context.getString(R.string.dropped_pin)
-        } else {
-            title.text = simpleFeature.name()
-        }
+        title.text = displayHelper.getDisplayName(simpleFeature)
         address.text = simpleFeature.address()
         start.setOnClickListener {
             if (permissionManager.permissionsGranted()) {

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -3,6 +3,7 @@ package com.mapzen.erasermap;
 import com.mapzen.android.search.MapzenSearch;
 import com.mapzen.erasermap.model.ApiKeys;
 import com.mapzen.erasermap.model.AppSettings;
+import com.mapzen.erasermap.model.ConfidenceHandler;
 import com.mapzen.erasermap.model.IntentQueryParser;
 import com.mapzen.erasermap.model.LocationConverter;
 import com.mapzen.erasermap.model.LocationSettingsChecker;
@@ -19,6 +20,7 @@ import com.mapzen.erasermap.model.TileHttpHandler;
 import com.mapzen.erasermap.presenter.MainPresenter;
 import com.mapzen.erasermap.presenter.MainPresenterImpl;
 import com.mapzen.erasermap.presenter.ViewStateManager;
+import com.mapzen.erasermap.util.FeatureDisplayHelper;
 import com.mapzen.erasermap.util.IntentFactory;
 import com.mapzen.erasermap.util.MockIntentFactory;
 import com.mapzen.erasermap.view.Speaker;
@@ -116,5 +118,13 @@ public class TestAndroidModule {
 
     @Provides @Singleton LocationSettingsChecker provideLocationSettingsChecker() {
         return new TestLostSettingsChecker();
+    }
+
+    @Provides @Singleton ConfidenceHandler provideConfidenceHandler(MainPresenter presenter) {
+        return new ConfidenceHandler(presenter);
+    }
+
+    @Provides @Singleton FeatureDisplayHelper provideDisplayHelper(ConfidenceHandler confidenceHandler) {
+        return new FeatureDisplayHelper(application, confidenceHandler);
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/util/FeatureDisplayHelperTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/util/FeatureDisplayHelperTest.kt
@@ -1,0 +1,93 @@
+package com.mapzen.erasermap.util
+
+import android.content.Context
+import com.mapzen.erasermap.R
+import com.mapzen.erasermap.model.ConfidenceHandler
+import com.mapzen.erasermap.model.IntentQueryParser
+import com.mapzen.erasermap.model.LocationConverter
+import com.mapzen.erasermap.model.PermissionManager
+import com.mapzen.erasermap.model.TestAppSettings
+import com.mapzen.erasermap.model.TestLostSettingsChecker
+import com.mapzen.erasermap.model.TestMapzenLocation
+import com.mapzen.erasermap.model.TestRouteManager
+import com.mapzen.erasermap.presenter.MainPresenterImpl
+import com.mapzen.erasermap.presenter.TestLostClientManager
+import com.mapzen.erasermap.presenter.ViewStateManager
+import com.mapzen.pelias.SimpleFeature
+import com.mapzen.tangram.LngLat
+import com.squareup.otto.Bus
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+
+class FeatureDisplayHelperTest {
+
+  lateinit var helper: FeatureDisplayHelper
+  lateinit var presenter: MainPresenterImpl
+  lateinit var confidenceHandler: ConfidenceHandler
+  lateinit var context: Context
+  val droppedPin = "Dropped Pin"
+  val galvanize = "Galvanize"
+
+  @Before fun setup(){
+    val mapzenLocation: TestMapzenLocation = TestMapzenLocation()
+    val routeManager: TestRouteManager = TestRouteManager()
+    val settings: TestAppSettings = TestAppSettings()
+    val bus: Bus = Bus()
+    val vsm: ViewStateManager = ViewStateManager()
+    val iqp: IntentQueryParser = Mockito.mock(IntentQueryParser::class.java)
+    val converter: LocationConverter = LocationConverter()
+    val clientManager: TestLostClientManager = TestLostClientManager()
+    val locationSettingsChecker = TestLostSettingsChecker()
+    val permissionManager = PermissionManager()
+    presenter = MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm, iqp,
+        converter, clientManager, locationSettingsChecker, permissionManager)
+    confidenceHandler = ConfidenceHandler(presenter)
+    context = Mockito.spy(Context::class.java)
+    `when`(context.getString(R.string.dropped_pin)).thenReturn(droppedPin)
+    helper = FeatureDisplayHelper(context, confidenceHandler)
+  }
+
+  @Test fun getDisplayName_missingConfidence_shouldReturnDroppedPin() {
+    confidenceHandler.longPressed = true
+    presenter.reverseGeoLngLat = LngLat(0.0, 0.0)
+    val feature = SimpleFeature.create("1", "1", galvanize, "",
+        "", "", "", "", "", "", "", 0.0, "", "", 0.0, 0.0)
+    val displayName = helper.getDisplayName(feature)
+    assertThat(displayName).isEqualTo(droppedPin)
+  }
+
+  @Test fun getDisplayName_notLongPressed_shouldReturnFeatureName() {
+    val feature = SimpleFeature.create("1", "1", galvanize, "",
+        "", "", "", "", "", "", "", 1.0, "", "", 0.0, 0.0)
+    val displayName = helper.getDisplayName(feature)
+    assertThat(displayName).isEqualTo(galvanize)
+  }
+
+  @Test fun getDisplayName_lowConfidenceReverseGeo_shouldReturnDroppedPin() {
+    confidenceHandler.longPressed = true
+    presenter.reverseGeoLngLat = LngLat(0.0, 0.0)
+    val feature = SimpleFeature.create("1", "1", galvanize, "",
+        "", "", "", "", "", "", "", 0.7, "", "", 0.0, 0.0)
+    val displayName = helper.getDisplayName(feature)
+    assertThat(displayName).isEqualTo(droppedPin)
+  }
+
+  @Test fun getDisplayName_highConfidenceReverseGeo_shouldReturnFeatureName() {
+    confidenceHandler.longPressed = true
+    presenter.reverseGeoLngLat = LngLat(0.0, 0.0)
+    val feature = SimpleFeature.create("1", "1", galvanize, "",
+        "", "", "", "", "", "", "", 0.9, "", "", 0.0, 0.0)
+    val displayName = helper.getDisplayName(feature)
+    assertThat(displayName).isEqualTo(galvanize)
+  }
+
+  @Test fun getDisplayName_blankFeatureName_shouldReturnDroppedPin() {
+    val feature = SimpleFeature.create("1", "1", "", "",
+        "", "", "", "", "", "", "", 0.7, "", "", 0.0, 0.0)
+    val displayName = helper.getDisplayName(feature)
+    assertThat(displayName).isEqualTo(droppedPin)
+  }
+}

--- a/app/src/test/kotlin/com/mapzen/erasermap/view/InstructionGrouperTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/view/InstructionGrouperTest.kt
@@ -1,7 +1,6 @@
 package com.mapzen.erasermap.view
 
 import com.mapzen.erasermap.TestUtils
-import com.mapzen.erasermap.view.InstructionGrouper
 import com.mapzen.valhalla.Instruction
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before


### PR DESCRIPTION
- Creates new `FeatureDisplayHelper` class to handle generating display text for a `SimpleFeature`
- Migrates all places in the app where a `SimpleFeature` is displayed to use `FeatureDisplayHelper` 
- Fixes bug where destination text would be blank in route preview view if the feature did not have a name

Closes #769