### PR TITLE
Improve test coverage in MainPresenter

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -172,7 +172,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
 
     override fun onNewIntent(intent: Intent?) {
         if (intent?.getBooleanExtra(NotificationCreator.EXIT_NAVIGATION, false) as Boolean) {
-            exitNavigation()
+            presenter.onExitNavigation()
             if((intent?.getBooleanExtra(NotificationBroadcastReceiver.VISIBILITY, false)
                     as Boolean).not()) {
                 moveTaskToBack(true)
@@ -580,7 +580,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         return layoutParams
     }
 
-    private fun layoutFindMeAlignBottom() {
+    override fun layoutFindMeAlignBottom() {
         val layoutParams = baseFindMeParams()
         layoutParams.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM)
         val margin = resources.getDimensionPixelSize(R.dimen.em_find_me_button_margin_bottom)
@@ -952,14 +952,22 @@ class MainActivity : AppCompatActivity(), MainViewController,
 
     override fun hideRoutePreview() {
         if((findViewById(R.id.route_mode) as RouteModeView).visibility != View.VISIBLE) {
-            supportActionBar?.show()
+            showActionBar()
             routeManager.reverse = false
-            findViewById(R.id.route_preview)?.visibility = View.GONE
+            hideRoutePreviewView()
             hideRoutePins()
             val features = arrayListOf(presenter.currentFeature) as List<Feature>
             layoutAttributionAboveSearchResults(features)
             layoutFindMeAboveSearchResults(features)
         }
+    }
+
+    override fun hideRoutePreviewView() {
+        routePreviewView.visibility = View.GONE
+    }
+
+    override fun showActionBar() {
+        supportActionBar?.show()
     }
 
     override fun route() {
@@ -1091,7 +1099,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         }
     }
 
-    private fun setDefaultCamera() {
+    override fun setDefaultCamera() {
         mapzenMap?.cameraType = CameraType.ISOMETRIC
     }
 
@@ -1108,12 +1116,20 @@ class MainActivity : AppCompatActivity(), MainViewController,
         presenter.routingEnabled = false
         setDefaultCamera()
         checkPermissionAndEnableLocation()
-        routeModeView.visibility = View.GONE
+        hideRouteModeView()
         supportActionBar?.hide()
         routeModeView.route = null
-        routeModeView.hideRouteIcon()
+        hideRouteIcon()
         routeModeView.hideResumeButton()
         hideReverseGeolocateResult()
+    }
+
+    override fun hideRouteIcon() {
+        routeModeView.hideRouteIcon()
+    }
+
+    override fun hideRouteModeView() {
+        routeModeView.visibility = View.GONE
     }
 
     override fun overridePlaceFeature(feature: Feature) {
@@ -1143,21 +1159,6 @@ class MainActivity : AppCompatActivity(), MainViewController,
 
     override fun stopSpeaker() {
         voiceNavigationController?.stop()
-    }
-
-    private fun exitNavigation() {
-        checkPermissionAndEnableLocation()
-        routeModeView.voiceNavigationController?.stop()
-        routeModeView.clearRoute()
-        routeModeView.route = null
-        routeModeView.hideRouteIcon()
-        routeModeView.visibility = View.GONE
-        supportActionBar?.show()
-        findViewById(R.id.route_preview)?.visibility = View.GONE
-        presenter.onExitNavigation()
-        mapzenMap?.setPanResponder(null)
-        setDefaultCamera()
-        layoutFindMeAlignBottom()
     }
 
     private fun getGenericLocationFeature(lat: Double, lon: Double) : Feature {
@@ -1258,5 +1259,13 @@ class MainActivity : AppCompatActivity(), MainViewController,
                 onRouteFailure(statusCode)
             }
         }
+    }
+
+    override fun stopVoiceNavigationController() {
+        routeModeView.voiceNavigationController?.stop()
+    }
+
+    override fun resetMapPanResponder() {
+        mapzenMap?.setPanResponder(null)
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -711,7 +711,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     override fun addSearchResultsToMap(features: List<Feature>?, activeIndex: Int) {
-        if (features == null) {
+        if (features == null || features.size == 0) {
             return
         }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -715,7 +715,11 @@ class MainActivity : AppCompatActivity(), MainViewController,
             return
         }
 
-        centerOnCurrentFeature(features)
+        val position = getCurrentSearchPosition()
+        setCurrentSearchItem(position)
+        val feature = SimpleFeature.fromFeature(features[position])
+        setMapPosition(LngLat(feature.lng(), feature.lat()), 1000)
+        setMapZoom(MainPresenter.DEFAULT_ZOOM)
 
         mapzenMap?.clearSearchResults()
         val points: ArrayList<LngLat> = ArrayList()
@@ -727,28 +731,22 @@ class MainActivity : AppCompatActivity(), MainViewController,
         mapzenMap?.drawSearchResults(points, activeIndex)
     }
 
-    override fun centerOnCurrentFeature(features: List<Feature>?) {
-        if (features == null) {
-            return
-        }
-
-        centerOnFeature(features, searchController.getCurrentItem())
+    override fun getCurrentSearchPosition(): Int {
+        return searchController.getCurrentItem()
     }
 
-    override fun centerOnFeature(features: List<Feature>?, position: Int) {
-        if (features == null) {
-            return
-        }
-
-        if(features.size > 0) {
-            searchController.setCurrentItem(position)
-            val feature = SimpleFeature.fromFeature(features[position])
-            Handler().postDelayed({
-                mapzenMap?.setPosition(LngLat(feature.lng(), feature.lat()), 1000)
-                mapzenMap?.zoom = MainPresenter.DEFAULT_ZOOM
-            }, 100)
-        }
+    override fun setCurrentSearchItem(position: Int) {
+        searchController.setCurrentItem(position)
     }
+
+    override fun setMapPosition(lngLat: LngLat, duration: Int) {
+        mapzenMap?.setPosition(lngLat, duration)
+    }
+
+    override fun setMapZoom(zoom: Float) {
+        mapzenMap?.zoom = zoom
+    }
+
 
     override fun placeSearch(gid: String) {
         mapzenSearch.setLocationProvider(presenter.getPeliasLocationProvider())

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -588,7 +588,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         mapView.findMe.layoutParams = layoutParams
     }
 
-    private fun layoutAttributionAboveSearchResults(features: List<Feature>) {
+    override fun layoutAttributionAboveSearchResults(features: List<Feature>) {
         if (features.count() == 0) return
         val layoutParams = baseAttributionParams()
         val bottomMargin = resources.getDimensionPixelSize(R.dimen.em_attribution_margin_bottom)
@@ -619,7 +619,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         }
     }
 
-    private fun layoutFindMeAboveSearchResults(features: List<Feature>) {
+    override fun layoutFindMeAboveSearchResults(features: List<Feature>) {
         if (features.count() == 0) return
         val layoutParams = baseFindMeParams()
         val bottomMargin = resources.getDimensionPixelSize(R.dimen.em_find_me_button_margin_bottom)
@@ -906,7 +906,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
             }
         }
 
-        hideRoutePins()
+        hideMapRoutePins()
         showRoutePins(LngLat(start.longitude, start.latitude),
                 LngLat(finish.longitude, finish.latitude))
     }
@@ -916,7 +916,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     private fun handleRouteFailure() {
-        hideRoutePins()
+        hideMapRoutePins()
         routeModeView.hideRouteLine()
 
         val origin = routeManager.origin
@@ -948,18 +948,6 @@ class MainActivity : AppCompatActivity(), MainViewController,
         })
         hideProgress()
         routePreviewView.disableStartNavigation()
-    }
-
-    override fun hideRoutePreview() {
-        if((findViewById(R.id.route_mode) as RouteModeView).visibility != View.VISIBLE) {
-            showActionBar()
-            routeManager.reverse = false
-            hideRoutePreviewView()
-            hideRoutePins()
-            val features = arrayListOf(presenter.currentFeature) as List<Feature>
-            layoutAttributionAboveSearchResults(features)
-            layoutFindMeAboveSearchResults(features)
-        }
     }
 
     override fun hideRoutePreviewView() {
@@ -1076,7 +1064,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
             showRoutingMode(feature)
             routeModeView.startRoute(feature, routeManager.route)
         }
-        hideRoutePins()
+        hideMapRoutePins()
     }
 
     override fun resetMute() {
@@ -1183,7 +1171,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
         mapzenMap?.isMyLocationEnabled = false
     }
 
-    private fun hideRoutePins() {
+    override fun hideMapRoutePins() {
         mapzenMap?.clearRoutePins()
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -28,7 +28,6 @@ interface MainViewController {
     fun clearQuery()
     fun showRoutePreviewDestination(destination: SimpleFeature)
     fun route()
-    fun hideRoutePreview()
     fun hideRoutingMode()
     fun startRoutingMode(feature: Feature, isNew: Boolean)
     fun resumeRoutingMode(feature: Feature)
@@ -77,4 +76,7 @@ interface MainViewController {
     fun resetMapPanResponder()
     fun setDefaultCamera()
     fun layoutFindMeAlignBottom()
+    fun hideMapRoutePins()
+    fun layoutAttributionAboveSearchResults(features: List<Feature>)
+    fun layoutFindMeAboveSearchResults(features: List<Feature>)
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -12,8 +12,6 @@ interface MainViewController {
     fun addSearchResultsToMap(features: List<Feature>?, activeIndex: Int)
     fun showDirectionsList()
     fun hideDirectionsList()
-    fun centerOnCurrentFeature(features: List<Feature>?)
-    fun centerOnFeature(features: List<Feature>?, position: Int)
     fun toggleShowAllSearchResultsList(features: List<Feature>?)
     fun hideSearchResults()
     fun hideReverseGeolocateResult()
@@ -79,4 +77,8 @@ interface MainViewController {
     fun hideMapRoutePins()
     fun layoutAttributionAboveSearchResults(features: List<Feature>)
     fun layoutFindMeAboveSearchResults(features: List<Feature>)
+    fun setCurrentSearchItem(position: Int)
+    fun setMapPosition(lngLat: LngLat, duration: Int)
+    fun setMapZoom(zoom: Float)
+    fun getCurrentSearchPosition(): Int
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -69,4 +69,12 @@ interface MainViewController {
     fun setRoutePreviewViewRoute(route: Route)
     fun showRoutePinsOnMap(locations: Array<ValhallaLocation>)
     fun updateRoutePreviewStartNavigation()
+    fun stopVoiceNavigationController()
+    fun hideRouteIcon()
+    fun hideRouteModeView()
+    fun showActionBar()
+    fun hideRoutePreviewView()
+    fun resetMapPanResponder()
+    fun setDefaultCamera()
+    fun layoutFindMeAlignBottom()
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -209,7 +209,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
         mainViewController?.showSearchResults(searchResults?.features)
       } else {
         mainViewController?.showReverseGeocodeFeature(searchResults?.features)
-        mainViewController?.centerOnCurrentFeature(searchResults?.features)
+        centerOnCurrentFeature(searchResults?.features)
       }
     }
   }
@@ -247,14 +247,14 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   override fun onSearchResultSelected(position: Int) {
     if (searchResults != null) {
       mainViewController?.addSearchResultsToMap(searchResults?.features, position)
-      mainViewController?.centerOnCurrentFeature(searchResults?.features)
+      centerOnCurrentFeature(searchResults?.features)
     }
   }
 
   override fun onSearchResultTapped(position: Int) {
     if (searchResults != null) {
       mainViewController?.addSearchResultsToMap(searchResults?.features, position)
-      mainViewController?.centerOnFeature(searchResults?.features, position)
+      centerOnFeature(searchResults?.features, position)
     }
   }
 
@@ -704,5 +704,28 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     routeManager.route = route
     mainViewController?.drawRoute(route)
     mainViewController?.hideProgress()
+  }
+
+  private fun featuresExist(features: List<Feature>?): Boolean {
+    return features != null || features!!.size > 0
+  }
+
+  private fun centerOnCurrentFeature(features: List<Feature>?) {
+    if (!featuresExist(features)) {
+      return
+    }
+    val position = mainViewController?.getCurrentSearchPosition()
+    centerOnFeature(features, position as Int)
+  }
+
+  private fun centerOnFeature(features: List<Feature>?, position: Int) {
+    if (!featuresExist(features)) {
+      return
+    }
+
+    mainViewController?.setCurrentSearchItem(position)
+    val feature = SimpleFeature.fromFeature(features!![position])
+    mainViewController?.setMapPosition(LngLat(feature.lng(), feature.lat()), 1000)
+    mainViewController?.setMapZoom(MainPresenter.DEFAULT_ZOOM)
   }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -512,8 +512,18 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
 
   override fun onExitNavigation() {
     vsm.viewState = ViewStateManager.ViewState.DEFAULT
-    routingEnabled = false;
+    routingEnabled = false
     routeManager.reverse = false
+    checkPermissionAndEnableLocation()
+    mainViewController?.stopVoiceNavigationController()
+    mainViewController?.clearRoute()
+    mainViewController?.hideRouteIcon()
+    mainViewController?.hideRouteModeView()
+    mainViewController?.showActionBar()
+    mainViewController?.hideRoutePreviewView()
+    mainViewController?.resetMapPanResponder()
+    mainViewController?.setDefaultCamera()
+    mainViewController?.layoutFindMeAlignBottom()
   }
 
   override fun onMapMotionEvent(): Boolean {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -524,6 +524,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     mainViewController?.resetMapPanResponder()
     mainViewController?.setDefaultCamera()
     mainViewController?.layoutFindMeAlignBottom()
+    mainViewController?.setMapTilt(0f)
   }
 
   override fun onMapMotionEvent(): Boolean {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -707,7 +707,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   private fun featuresExist(features: List<Feature>?): Boolean {
-    return features != null || features!!.size > 0
+    return features != null && features!!.size > 0
   }
 
   private fun centerOnCurrentFeature(features: List<Feature>?) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -353,7 +353,13 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
 
     mainViewController?.hideProgress()
     mainViewController?.cancelRouteRequest()
-    mainViewController?.hideRoutePreview()
+    mainViewController?.showActionBar()
+    routeManager.reverse = false
+    mainViewController?.hideRoutePreviewView()
+    mainViewController?.hideMapRoutePins()
+    val features = arrayListOf(currentFeature) as List<Feature>
+    mainViewController?.layoutAttributionAboveSearchResults(features)
+    mainViewController?.layoutFindMeAboveSearchResults(features)
     mainViewController?.clearRoute()
     if (searchResults != null) {
       if (reverseGeo) {

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -5,6 +5,7 @@ import com.mapzen.model.ValhallaLocation
 import com.mapzen.pelias.SimpleFeature
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.tangram.LngLat
+import com.mapzen.tangram.MapController
 import com.mapzen.valhalla.Route
 
 class TestMainController : MainViewController {
@@ -49,6 +50,12 @@ class TestMainController : MainViewController {
     var isRoutePreviewDistanceTieVisible = false
     var routePreviewRoute: Route? = null
     var routePinLocations: Array<ValhallaLocation>? = null
+    var isVoiceNavigationStopped = false
+    var isRouteIconVisible = true
+    var isRouteModeViewVisible = true
+    var isRoutePreviewViewVisible = true
+    var mapHasPanResponder = true
+    var mapCameraType = MapController.CameraType.PERSPECTIVE
 
     override fun showSearchResults(features: List<Feature>?) {
         searchResults = features
@@ -290,4 +297,37 @@ class TestMainController : MainViewController {
     override fun updateRoutePreviewStartNavigation() {
 
     }
+
+    override fun stopVoiceNavigationController() {
+        isVoiceNavigationStopped = true
+    }
+
+    override fun hideRouteIcon() {
+        isRouteIconVisible = false
+    }
+
+    override fun hideRouteModeView() {
+        isRouteModeViewVisible = false
+    }
+
+    override fun showActionBar() {
+        isActionBarHidden = false
+    }
+
+    override fun hideRoutePreviewView() {
+        isRoutePreviewViewVisible = false
+    }
+
+    override fun resetMapPanResponder() {
+        mapHasPanResponder = false
+    }
+
+    override fun setDefaultCamera() {
+        mapCameraType = MapController.CameraType.ISOMETRIC
+    }
+
+    override fun layoutFindMeAlignBottom() {
+        isFindMeAboveOptions = false
+    }
+
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -28,8 +28,6 @@ class TestMainController : MainViewController {
     var isRoutePreviewDestinationVisible: Boolean = false
     var isDirectionListVisible: Boolean = false
     var isRoutingModeVisible: Boolean = false
-    var isCenteredOnCurrentFeature: Boolean = false
-    var isCenteredOnTappedFeature: Boolean = false
     var isReverseGeocodeVisible: Boolean = false
     var isPlaceResultOverridden: Boolean = false
     var isSettingsVisible: Boolean = false
@@ -59,6 +57,7 @@ class TestMainController : MainViewController {
     var routePinsVisible = true
     var isAttributionAboveSearchResults = false
     var isFindMeAboveSearchResults = false
+    var currentSearchItemPosition = 0
 
     override fun showSearchResults(features: List<Feature>?) {
         searchResults = features
@@ -66,14 +65,6 @@ class TestMainController : MainViewController {
 
     override fun addSearchResultsToMap(features: List<Feature>?, activeIndex: Int) {
         searchResults = features;
-    }
-
-    override fun centerOnCurrentFeature(features: List<Feature>?) {
-        isCenteredOnCurrentFeature = true
-    }
-
-    override fun centerOnFeature(features: List<Feature>?, position: Int) {
-        isCenteredOnTappedFeature = true
     }
 
     override fun hideSearchResults() {
@@ -339,5 +330,21 @@ class TestMainController : MainViewController {
 
     override fun layoutFindMeAboveSearchResults(features: List<Feature>) {
         isFindMeAboveSearchResults = true
+    }
+
+    override fun setCurrentSearchItem(position: Int) {
+        currentSearchItemPosition = position
+    }
+
+    override fun setMapPosition(lngLat: LngLat, duration: Int) {
+        this.lngLat = lngLat
+    }
+
+    override fun setMapZoom(zoom: Float) {
+        this.zoom = zoom
+    }
+
+    override fun getCurrentSearchPosition(): Int {
+        return currentSearchItemPosition
     }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -56,6 +56,9 @@ class TestMainController : MainViewController {
     var isRoutePreviewViewVisible = true
     var mapHasPanResponder = true
     var mapCameraType = MapController.CameraType.PERSPECTIVE
+    var routePinsVisible = true
+    var isAttributionAboveSearchResults = false
+    var isFindMeAboveSearchResults = false
 
     override fun showSearchResults(features: List<Feature>?) {
         searchResults = features
@@ -117,10 +120,6 @@ class TestMainController : MainViewController {
 
     override fun route() {
         isRouting = true
-    }
-
-    override fun hideRoutePreview() {
-        isRoutePreviewVisible = false
     }
 
     override fun shutDown() {
@@ -330,4 +329,15 @@ class TestMainController : MainViewController {
         isFindMeAboveOptions = false
     }
 
+    override fun hideMapRoutePins() {
+        routePinsVisible = false
+    }
+
+    override fun layoutAttributionAboveSearchResults(features: List<Feature>) {
+        isAttributionAboveSearchResults = true
+    }
+
+    override fun layoutFindMeAboveSearchResults(features: List<Feature>) {
+        isFindMeAboveSearchResults = true
+    }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -609,7 +609,7 @@ class MainPresenterTest {
 
     @Test fun onBackPressed_shouldShowActionBarInStateRoutePreview() {
         vsm.viewState = ROUTE_PREVIEW
-        mainController.isActionBarHidden = false
+        mainController.isActionBarHidden = true
         presenter.onBackPressed()
         assertThat(mainController.isActionBarHidden).isFalse()
     }
@@ -1026,6 +1026,32 @@ class MainPresenterTest {
         mainController.tilt = 30f
         presenter.onExitNavigation()
         assertThat(mainController.tilt).isEqualTo(0f)
+    }
+
+    @Test fun centerOnCurrentFeature_shouldDoNothingForNoFeatures() {
+        val result = Result()
+        presenter.onSearchResultsAvailable(result)
+        mainController.currentSearchItemPosition = 3
+        val pos = LngLat(70.0, 40.0)
+        mainController.lngLat = pos
+        mainController.zoom = MainPresenter.ROUTING_ZOOM
+        presenter.onSearchResultSelected(0)
+        assertThat(mainController.currentSearchItemPosition).isEqualTo(3)
+        assertThat(mainController.lngLat).isEqualTo(pos)
+        assertThat(mainController.zoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
+    }
+
+    @Test fun centerOnFeature_shouldDoNothingForNoFeatures() {
+        val result = Result()
+        presenter.onSearchResultsAvailable(result)
+        mainController.currentSearchItemPosition = 3
+        val pos = LngLat(70.0, 40.0)
+        mainController.lngLat = pos
+        mainController.zoom = MainPresenter.ROUTING_ZOOM
+        presenter.onSearchResultTapped(0)
+        assertThat(mainController.currentSearchItemPosition).isEqualTo(3)
+        assertThat(mainController.lngLat).isEqualTo(pos)
+        assertThat(mainController.zoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
     }
 
     class RouteEventSubscriber {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -30,6 +30,7 @@ import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTING
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.SEARCH
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.SEARCH_RESULTS
 import com.mapzen.erasermap.view.TestRouteController
+import com.mapzen.pelias.SimpleFeature
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.gson.Result
 import com.mapzen.tangram.LngLat
@@ -467,19 +468,88 @@ class MainPresenterTest {
     @Test fun onSearchResultSelected_shouldCenterOnCurrentFeature() {
         val result = Result()
         val features = ArrayList<Feature>()
+        features.add(Feature())
+        features.add(Feature())
+        val feature = SimpleFeature.create("1", "1", "", "",
+            "", "", "", "", "", "", "", 0.0, "", "", 40.0, 70.0)
+        features.add(feature.toFeature())
         result.features = features
+        mainController.currentSearchItemPosition = 2
         presenter.onSearchResultsAvailable(result)
         presenter.onSearchResultSelected(0)
-        assertThat(mainController.isCenteredOnCurrentFeature).isTrue()
+        assertThat(mainController.currentSearchItemPosition).isEqualTo(2)
+    }
+
+    @Test fun onSearchResultSelected_shouldSetMapPositionForCurrentFeature() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        features.add(Feature())
+        features.add(Feature())
+        val feature = SimpleFeature.create("1", "1", "", "",
+            "", "", "", "", "", "", "", 0.0, "", "", 40.0, 70.0)
+        features.add(feature.toFeature())
+        result.features = features
+        mainController.currentSearchItemPosition = 2
+        presenter.onSearchResultsAvailable(result)
+        presenter.onSearchResultSelected(0)
+        assertThat(mainController.lngLat?.longitude).isEqualTo(70.0)
+        assertThat(mainController.lngLat?.latitude).isEqualTo(40.0)
+    }
+
+    @Test fun onSearchResultSelected_shouldSetMapZoomDefaultZoom() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        features.add(Feature())
+        features.add(Feature())
+        val feature = SimpleFeature.create("1", "1", "", "",
+            "", "", "", "", "", "", "", 0.0, "", "", 40.0, 70.0)
+        features.add(feature.toFeature())
+        result.features = features
+        mainController.currentSearchItemPosition = 2
+        presenter.onSearchResultsAvailable(result)
+        presenter.onSearchResultSelected(0)
+        assertThat(mainController.zoom).isEqualTo(16f)
     }
 
     @Test fun onSearchResultTapped_shouldCenterOnCurrentFeature() {
         val result = Result()
         val features = ArrayList<Feature>()
+        val feature = SimpleFeature.create("1", "1", "", "",
+            "", "", "", "", "", "", "", 0.0, "", "", 40.0, 70.0)
+        features.add(feature.toFeature())
         result.features = features
+        mainController.currentSearchItemPosition = 2
         presenter.onSearchResultsAvailable(result)
         presenter.onSearchResultTapped(0)
-        assertThat(mainController.isCenteredOnTappedFeature).isTrue()
+        assertThat(mainController.currentSearchItemPosition).isEqualTo(0)
+    }
+
+    @Test fun onSearchResultTapped_shouldSetMapPositionOfCurrentFeature() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        val feature = SimpleFeature.create("1", "1", "", "",
+            "", "", "", "", "", "", "", 0.0, "", "", 40.0, 70.0)
+        features.add(feature.toFeature())
+        result.features = features
+        mainController.currentSearchItemPosition = 2
+        presenter.onSearchResultsAvailable(result)
+        presenter.onSearchResultTapped(0)
+        assertThat(mainController.lngLat?.longitude).isEqualTo(70.0)
+        assertThat(mainController.lngLat?.latitude).isEqualTo(40.0)
+    }
+
+    @Test fun onSearchResultTapped_shouldSetMapZoomDefaultZoom() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        val feature = SimpleFeature.create("1", "1", "", "",
+            "", "", "", "", "", "", "", 0.0, "", "", 40.0, 70.0)
+        features.add(feature.toFeature())
+        result.features = features
+        mainController.currentSearchItemPosition = 2
+        presenter.onSearchResultsAvailable(result)
+        presenter.onSearchResultTapped(0)
+        assertThat(mainController.lngLat?.longitude).isEqualTo(70.0)
+        assertThat(mainController.lngLat?.latitude).isEqualTo(40.0)
     }
 
     @Test fun onBackPressed_shouldDisconnectLocationUpdates() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -476,7 +476,7 @@ class MainPresenterTest {
         result.features = features
         mainController.currentSearchItemPosition = 2
         presenter.onSearchResultsAvailable(result)
-        presenter.onSearchResultSelected(0)
+        presenter.onSearchResultSelected(2)
         assertThat(mainController.currentSearchItemPosition).isEqualTo(2)
     }
 
@@ -491,7 +491,7 @@ class MainPresenterTest {
         result.features = features
         mainController.currentSearchItemPosition = 2
         presenter.onSearchResultsAvailable(result)
-        presenter.onSearchResultSelected(0)
+        presenter.onSearchResultSelected(2)
         assertThat(mainController.lngLat?.longitude).isEqualTo(70.0)
         assertThat(mainController.lngLat?.latitude).isEqualTo(40.0)
     }

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -910,6 +910,12 @@ class MainPresenterTest {
         assertThat(mainController.isFindMeAboveOptions).isFalse()
     }
 
+    @Test fun onExitNavigation_shouldResetMapTilt() {
+        mainController.tilt = 30f
+        presenter.onExitNavigation()
+        assertThat(mainController.tilt).isEqualTo(0f)
+    }
+
     class RouteEventSubscriber {
         var event: RouteEvent? = null
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -33,6 +33,7 @@ import com.mapzen.erasermap.view.TestRouteController
 import com.mapzen.pelias.gson.Feature
 import com.mapzen.pelias.gson.Result
 import com.mapzen.tangram.LngLat
+import com.mapzen.tangram.MapController
 import com.mapzen.valhalla.Route
 import com.squareup.otto.Bus
 import com.squareup.otto.Subscribe
@@ -828,6 +829,85 @@ class MainPresenterTest {
         mainController.tilt = 30f
         presenter.onClickFindMe()
         assertThat(mainController.tilt).isEqualTo(0f)
+    }
+
+    @Test fun onExitNavigation_shouldSetViewStateDefault() {
+        vsm.viewState = ROUTING
+        presenter.onExitNavigation()
+        assertThat(vsm.viewState).isEqualTo(DEFAULT)
+    }
+
+    @Test fun onExitNavigation_shouldDisableRouting() {
+        presenter.routingEnabled = true
+        presenter.onExitNavigation()
+        assertThat(presenter.routingEnabled).isFalse()
+    }
+
+    @Test fun onExitNavigation_shouldResetReverse() {
+        routeManager.reverse = true
+        presenter.onExitNavigation()
+        assertThat(routeManager.reverse).isFalse()
+    }
+
+    @Test fun onExitNavigation_shouldEnableLocation() {
+        permissionManager.granted = true
+        mainController.isCurrentLocationEnabled = false
+        presenter.onExitNavigation()
+        assertThat(mainController.isCurrentLocationEnabled).isTrue()
+    }
+
+    @Test fun onExitNavigation_shouldStopVoiceNavigationController() {
+        mainController.isVoiceNavigationStopped = false
+        presenter.onExitNavigation()
+        assertThat(mainController.isVoiceNavigationStopped).isTrue()
+    }
+
+    @Test fun onExitNavigation_shouldClearRoute() {
+        mainController.routeLine = Route(JSONObject())
+        presenter.onExitNavigation()
+        assertThat(mainController.routeLine).isNull()
+    }
+
+    @Test fun onExitNavigation_shouldHideRouteIcon() {
+        mainController.isRouteIconVisible = true
+        presenter.onExitNavigation()
+        assertThat(mainController.isRouteIconVisible).isFalse()
+    }
+
+    @Test fun onExitNavigation_shouldHideRouteModeView() {
+        mainController.isRouteModeViewVisible = true
+        presenter.onExitNavigation()
+        assertThat(mainController.isRouteModeViewVisible).isFalse()
+    }
+
+    @Test fun onExitNavigation_shouldShowActionBar() {
+        mainController.isActionBarHidden = true
+        presenter.onExitNavigation()
+        assertThat(mainController.isActionBarHidden).isFalse()
+    }
+
+    @Test fun onExitNavigation_shouldHideRoutePreviewView() {
+        mainController.isRoutePreviewViewVisible = true
+        presenter.onExitNavigation()
+        assertThat(mainController.isRoutePreviewViewVisible).isFalse()
+    }
+
+    @Test fun onExitNavigation_shouldResetMapResponder() {
+        mainController.mapHasPanResponder = true
+        presenter.onExitNavigation()
+        assertThat(mainController.mapHasPanResponder).isFalse()
+    }
+
+    @Test fun onExitNavigation_shouldSetDefaultCamera() {
+        mainController.mapCameraType = MapController.CameraType.PERSPECTIVE
+        presenter.onExitNavigation()
+        assertThat(mainController.mapCameraType).isEqualTo(MapController.CameraType.ISOMETRIC)
+    }
+
+    @Test fun onExitNavigation_shouldAlignFindMeToBottom() {
+        mainController.isFindMeAboveOptions = true
+        presenter.onExitNavigation()
+        assertThat(mainController.isFindMeAboveOptions).isFalse()
     }
 
     class RouteEventSubscriber {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -537,6 +537,48 @@ class MainPresenterTest {
         assertThat(mainController.routeRequestCanceled).isTrue()
     }
 
+    @Test fun onBackPressed_shouldShowActionBarInStateRoutePreview() {
+        vsm.viewState = ROUTE_PREVIEW
+        mainController.isActionBarHidden = false
+        presenter.onBackPressed()
+        assertThat(mainController.isActionBarHidden).isFalse()
+    }
+
+    @Test fun onBackPressed_shouldUpdateReverseToFalseInStateRoutePreview() {
+        vsm.viewState = ROUTE_PREVIEW
+        routeManager.reverse = true
+        presenter.onBackPressed()
+        assertThat(routeManager.reverse).isFalse()
+    }
+
+    @Test fun onBackPressed_shouldHideRoutePreviewViewInStateRoutePreview() {
+        vsm.viewState = ROUTE_PREVIEW
+        mainController.isRoutePreviewViewVisible = true
+        presenter.onBackPressed()
+        assertThat(mainController.isRoutePreviewViewVisible).isFalse()
+    }
+
+    @Test fun onBackPressed_shouldHideMapRoutePinsInStateRoutePreview() {
+        vsm.viewState = ROUTE_PREVIEW
+        mainController.routePinsVisible = true
+        presenter.onBackPressed()
+        assertThat(mainController.routePinsVisible).isFalse()
+    }
+
+    @Test fun onBackPressed_shouldLayoutAttributionAboveSearchResultsInStateRoutePreview() {
+        vsm.viewState = ROUTE_PREVIEW
+        mainController.isAttributionAboveSearchResults = false
+        presenter.onBackPressed()
+        assertThat(mainController.isAttributionAboveSearchResults).isTrue()
+    }
+
+    @Test fun onBackPressed_shouldLayoutFindMeAboveSearchResultsInStateRoutePreview() {
+        vsm.viewState = ROUTE_PREVIEW
+        mainController.isFindMeAboveSearchResults = false
+        presenter.onBackPressed()
+        assertThat(mainController.isFindMeAboveSearchResults).isTrue()
+    }
+
     @Test fun configureMapzenMap_shouldSetMapLocationFirstTimeInvoked() {
         presenter.configureMapzenMap()
         assertThat(mainController.lngLat).isNotNull()


### PR DESCRIPTION
This PR moves logic for exiting navigation, hiding route preview, and centering on features out of the `MainActivity` and into the `MainPresenter` as well as increases test coverage. It replaces large methods with simple calls to UI elements in `MainActivity`. It also adds a fix to reset the tilt when navigation mode is exited. There is a lot more work to do here, this is just a start...