### PR TITLE
ConfidenceHandler refactor

### DIFF
--- a/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
+++ b/app/src/main/java/com/mapzen/erasermap/AndroidModule.java
@@ -77,10 +77,10 @@ public class AndroidModule {
             RouteManager routeManager, AppSettings settings, ViewStateManager vsm,
             IntentQueryParser intentQueryParser, LocationConverter converter,
             LostClientManager clientManager, LocationSettingsChecker locationSettingsChecker,
-            PermissionManager permissionManager) {
+            PermissionManager permissionManager, ConfidenceHandler confidenceHandler) {
         return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm,
                 intentQueryParser, converter, clientManager, locationSettingsChecker,
-                permissionManager);
+                permissionManager, confidenceHandler);
     }
 
     @Provides @Singleton RouteManager provideRouteManager(AppSettings settings, ApiKeys apiKeys) {
@@ -147,8 +147,8 @@ public class AndroidModule {
         return new LostSettingsChecker();
     }
 
-    @Provides @Singleton ConfidenceHandler provideConfidenceHandler(MainPresenter mainPresenter) {
-        return new ConfidenceHandler(mainPresenter);
+    @Provides @Singleton ConfidenceHandler provideConfidenceHandler() {
+        return new ConfidenceHandler();
     }
 
     @Provides @Singleton FeatureDisplayHelper provideDisplayHelper(

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
@@ -1,10 +1,11 @@
 package com.mapzen.erasermap.model
 
-import com.mapzen.erasermap.presenter.MainPresenter
+import com.mapzen.tangram.LngLat
 
-class ConfidenceHandler(val presenter: MainPresenter) {
+class ConfidenceHandler() {
 
     var longPressed = false
+    var reverseGeoLngLat: LngLat? = null
 
     companion object {
         const val CONFIDENCE_THRESHOLD = 0.8
@@ -15,8 +16,8 @@ class ConfidenceHandler(val presenter: MainPresenter) {
         if (confidence == CONFIDENCE_MISSING || !longPressed) {
             return false
         }
-        return confidence < CONFIDENCE_THRESHOLD
-                && presenter.reverseGeoLngLat != null
+
+        return confidence < CONFIDENCE_THRESHOLD && reverseGeoLngLat != null
     }
 
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
@@ -5,8 +5,8 @@ import com.mapzen.tangram.LngLat
 /**
  * Uses the following criteria to determine if raw lat/lng should be used for reverse geocode:
  *
- * * Pelias confidence score<
- * * Whether the reverse geocode was initiated by a long press
+ * * Pelias confidence score.
+ * * Whether the reverse geocode was initiated by a long press.
  * * Lat/lng coordinates returned in the reverse geocode result.
  */
 class ConfidenceHandler() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ConfidenceHandler.kt
@@ -2,22 +2,37 @@ package com.mapzen.erasermap.model
 
 import com.mapzen.tangram.LngLat
 
+/**
+ * Uses the following criteria to determine if raw lat/lng should be used for reverse geocode:
+ *
+ * * Pelias confidence score<
+ * * Whether the reverse geocode was initiated by a long press
+ * * Lat/lng coordinates returned in the reverse geocode result.
+ */
 class ConfidenceHandler() {
 
-    var longPressed = false
-    var reverseGeoLngLat: LngLat? = null
+  var longPressed = false
+  var reverseGeoLngLat: LngLat? = null
 
-    companion object {
-        const val CONFIDENCE_THRESHOLD = 0.8
-        const val CONFIDENCE_MISSING = -1.0
+  companion object {
+    const val CONFIDENCE_THRESHOLD = 0.8
+    const val CONFIDENCE_MISSING = -1.0
+  }
+
+  /**
+   * Returns true if the raw lat/lng values should be used. Otherwise false.
+   */
+  fun useRawLatLng(confidence: Double): Boolean {
+    if (!hasConfidence(confidence) || !longPressed) {
+      return false
     }
 
-    fun useRawLatLng(confidence: Double): Boolean {
-        if (confidence == CONFIDENCE_MISSING || !longPressed) {
-            return false
-        }
+    return isConfidenceBelowThreshold(confidence) && hasReverseGeoLngLat()
+  }
 
-        return confidence < CONFIDENCE_THRESHOLD && reverseGeoLngLat != null
-    }
+  private fun hasConfidence(confidence: Double) = confidence != CONFIDENCE_MISSING
 
+  private fun isConfidenceBelowThreshold(confidence: Double) = confidence < CONFIDENCE_THRESHOLD
+
+  private fun hasReverseGeoLngLat() = reverseGeoLngLat != null
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -47,8 +47,8 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     val routeManager: RouteManager, val settings: AppSettings, val vsm: ViewStateManager,
     val intentQueryParser: IntentQueryParser, val converter: LocationConverter,
     val locationClientManager: LocationClientManager,
-    val locationSettingsChecker: LocationSettingsChecker, val permissionManager: PermissionManager):
-    MainPresenter, RouteCallback {
+    val locationSettingsChecker: LocationSettingsChecker, val permissionManager: PermissionManager,
+    val confidenceHandler: ConfidenceHandler) : MainPresenter, RouteCallback {
 
   companion object {
     private val TAG = MainPresenterImpl::class.java.simpleName
@@ -63,7 +63,11 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   override var currentSearchTerm: String? = null
   override var resultListVisible = false
   override var reverseGeo = false
-  override var reverseGeoLngLat: LngLat? = null
+  override var reverseGeoLngLat: LngLat?
+    get() = confidenceHandler.reverseGeoLngLat
+    set(value) {
+      confidenceHandler.reverseGeoLngLat = value
+    }
 
   private var searchResults: Result? = null
   private var destination: Feature? = null
@@ -618,7 +622,6 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
       routeManager.bearing = null
     }
 
-    val confidenceHandler = ConfidenceHandler(this)
     if (!confidenceHandler.useRawLatLng(feature.properties.confidence)) {
       mainViewController?.showRoutePreviewDestination(SimpleFeature.fromFeature(feature))
       routeManager.destination = feature

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -72,10 +72,10 @@ public class TestAndroidModule {
             RouteManager routeManager, AppSettings settings, ViewStateManager vsm,
             IntentQueryParser intentQueryParser, LocationConverter converter,
             LostClientManager lostClientManager, LocationSettingsChecker locationSettingsChecker,
-            PermissionManager permissionManager) {
+            PermissionManager permissionManager, ConfidenceHandler confidenceHandler) {
         return new MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm,
                 intentQueryParser, converter, lostClientManager, locationSettingsChecker,
-            permissionManager);
+            permissionManager, confidenceHandler);
     }
 
     @Provides @Singleton RouteManager provideRouteManager() {
@@ -120,8 +120,8 @@ public class TestAndroidModule {
         return new TestLostSettingsChecker();
     }
 
-    @Provides @Singleton ConfidenceHandler provideConfidenceHandler(MainPresenter presenter) {
-        return new ConfidenceHandler(presenter);
+    @Provides @Singleton ConfidenceHandler provideConfidenceHandler() {
+        return new ConfidenceHandler();
     }
 
     @Provides @Singleton FeatureDisplayHelper provideDisplayHelper(ConfidenceHandler confidenceHandler) {

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ConfidenceHandlerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ConfidenceHandlerTest.kt
@@ -1,0 +1,41 @@
+package com.mapzen.erasermap.model
+
+import com.mapzen.tangram.LngLat
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+
+class ConfidenceHandlerTest {
+  val confidenceHandler = ConfidenceHandler()
+
+  @Test fun shouldNotBeNull() {
+    assertThat(confidenceHandler).isNotNull()
+  }
+
+  @Test fun useRawLatLng_shouldReturnFalseIfMissingConfidenceScore() {
+    assertThat(confidenceHandler.useRawLatLng(ConfidenceHandler.CONFIDENCE_MISSING)).isFalse()
+  }
+
+  @Test fun useRawLatLng_shouldReturnFalseIfNotOriginatedFromLongPress() {
+    confidenceHandler.longPressed = false
+    assertThat(confidenceHandler.useRawLatLng(ConfidenceHandler.CONFIDENCE_THRESHOLD)).isFalse()
+  }
+
+  @Test fun useRawLatLng_shouldReturnFalseIfConfidenceIsNotLessThanThresholdValue() {
+    confidenceHandler.longPressed = true
+    confidenceHandler.reverseGeoLngLat = LngLat(0.0, 0.0)
+    assertThat(confidenceHandler.useRawLatLng(ConfidenceHandler.CONFIDENCE_THRESHOLD)).isFalse()
+  }
+
+  @Test fun useRawLatLng_shouldReturnFalseIfReverseGeoLngLatIsNull() {
+    confidenceHandler.longPressed = true
+    confidenceHandler.reverseGeoLngLat = null
+    assertThat(confidenceHandler.useRawLatLng(ConfidenceHandler.CONFIDENCE_THRESHOLD)).isFalse()
+  }
+
+  @Test fun useRawLatLng_shouldReturnTrueIfAllConditionsAreMet() {
+    confidenceHandler.longPressed = true
+    confidenceHandler.reverseGeoLngLat = LngLat(0.0, 0.0)
+    assertThat(confidenceHandler.useRawLatLng(ConfidenceHandler.CONFIDENCE_THRESHOLD - 1)).isTrue()
+  }
+}

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -7,6 +7,7 @@ import com.mapzen.erasermap.dummy.TestHelper.getFixture
 import com.mapzen.erasermap.dummy.TestHelper.getTestAndroidLocation
 import com.mapzen.erasermap.dummy.TestHelper.getTestFeature
 import com.mapzen.erasermap.dummy.TestHelper.getTestLocation
+import com.mapzen.erasermap.model.ConfidenceHandler
 import com.mapzen.erasermap.model.IntentQuery
 import com.mapzen.erasermap.model.IntentQueryParser
 import com.mapzen.erasermap.model.LocationClientManager
@@ -60,8 +61,9 @@ class MainPresenterTest {
     private val clientManager: TestLostClientManager = TestLostClientManager()
     private val locationSettingsChecker = TestLostSettingsChecker()
     private val permissionManager = PermissionManager()
+    private val confidenceHandler = ConfidenceHandler()
     private val presenter = MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm, iqp,
-        converter, clientManager, locationSettingsChecker, permissionManager)
+        converter, clientManager, locationSettingsChecker, permissionManager, confidenceHandler)
 
     @Before fun setUp() {
         presenter.mainViewController = mainController
@@ -393,7 +395,8 @@ class MainPresenterTest {
     @Test fun onRoutePreviewEvent_shouldTriggerSettingsApi() {
         val resolutionSettingsChecker = ResolutionLocationSettingsChecker()
         val testPresenter = MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm, iqp,
-            converter, clientManager, resolutionSettingsChecker, permissionManager)
+            converter, clientManager, resolutionSettingsChecker, permissionManager,
+            confidenceHandler)
         testPresenter.mainViewController = mainController
 
         testPresenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))

--- a/app/src/test/kotlin/com/mapzen/erasermap/util/FeatureDisplayHelperTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/util/FeatureDisplayHelperTest.kt
@@ -42,9 +42,9 @@ class FeatureDisplayHelperTest {
     val clientManager: TestLostClientManager = TestLostClientManager()
     val locationSettingsChecker = TestLostSettingsChecker()
     val permissionManager = PermissionManager()
+    confidenceHandler = ConfidenceHandler()
     presenter = MainPresenterImpl(mapzenLocation, bus, routeManager, settings, vsm, iqp,
-        converter, clientManager, locationSettingsChecker, permissionManager)
-    confidenceHandler = ConfidenceHandler(presenter)
+        converter, clientManager, locationSettingsChecker, permissionManager, confidenceHandler)
     context = Mockito.spy(Context::class.java)
     `when`(context.getString(R.string.dropped_pin)).thenReturn(droppedPin)
     helper = FeatureDisplayHelper(context, confidenceHandler)


### PR DESCRIPTION
As a model `ConfidenceHandler` should not know about the presenter. This change removes `MainPresenter` as a dependency of `ConfidenceHandler` and instead uses constructor injection to provide an instance of `ConfidenceHandler` to the presenter when it is created.

This also refactors `MainPresenter` to not track `reverseGeoLngLat` itself but instead store that information in the `ConfidenceHandler` model.

Finally it adds unit tests and docs to `ConfidenceHandler`.