### PR TITLE
Preserve search pager position on rotation & backing out of route preview

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -719,9 +719,8 @@ class MainActivity : AppCompatActivity(), MainViewController,
             return
         }
 
-        val position = getCurrentSearchPosition()
-        setCurrentSearchItem(position)
-        val feature = SimpleFeature.fromFeature(features[position])
+        setCurrentSearchItem(activeIndex)
+        val feature = SimpleFeature.fromFeature(features[activeIndex])
         setMapPosition(LngLat(feature.lng(), feature.lat()), 1000)
         setMapZoom(MainPresenter.DEFAULT_ZOOM)
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -534,13 +534,17 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     override fun showSearchResults(features: List<Feature>?) {
+        showSearchResults(features, 0)
+    }
+
+    override fun showSearchResults(features: List<Feature>?, activeIndex: Int) {
         if (features == null) {
             return
         }
 
         hideReverseGeolocateResult()
         showSearchResultsView(features)
-        addSearchResultsToMap(features, 0)
+        addSearchResultsToMap(features, activeIndex)
         layoutAttributionAboveSearchResults(features)
         layoutFindMeAboveSearchResults(features)
         toggleShowDebugSettings()

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -9,6 +9,7 @@ import com.mapzen.valhalla.Route
 
 interface MainViewController {
     fun showSearchResults(features: List<Feature>?)
+    fun showSearchResults(features: List<Feature>?, currentIndex: Int)
     fun addSearchResultsToMap(features: List<Feature>?, activeIndex: Int)
     fun showDirectionsList()
     fun hideDirectionsList()

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -26,6 +26,7 @@ interface MainPresenter {
     var resultListVisible: Boolean
     var reverseGeo: Boolean
     var reverseGeoLngLat: LngLat?
+    var currentSearchIndex: Int
 
     fun onSearchResultsAvailable(result: Result?)
     fun onReverseGeocodeResultsAvailable(searchResults: Result?)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -68,6 +68,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     set(value) {
       confidenceHandler.reverseGeoLngLat = value
     }
+  override var currentSearchIndex: Int = 0
 
   private var searchResults: Result? = null
   private var destination: Feature? = null
@@ -210,7 +211,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   private fun onRestoreMapStateSearchResults() {
     if (searchResults?.features != null) {
       if (!reverseGeo) {
-        mainViewController?.showSearchResults(searchResults?.features)
+        mainViewController?.showSearchResults(searchResults?.features, currentSearchIndex)
       } else {
         mainViewController?.showReverseGeocodeFeature(searchResults?.features)
         centerOnCurrentFeature(searchResults?.features)
@@ -249,6 +250,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   override fun onSearchResultSelected(position: Int) {
+    currentSearchIndex = position
     if (searchResults != null) {
       mainViewController?.addSearchResultsToMap(searchResults?.features, position)
       centerOnCurrentFeature(searchResults?.features)
@@ -369,7 +371,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
       if (reverseGeo) {
         mainViewController?.showReverseGeocodeFeature(searchResults?.features)
       } else {
-        mainViewController?.showSearchResults(searchResults?.features)
+        mainViewController?.showSearchResults(searchResults?.features, currentSearchIndex)
         var numFeatures = 0
         numFeatures = (searchResults?.features?.size as Int)
         if (numFeatures > 1) {

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -91,6 +91,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     vsm.viewState = ViewStateManager.ViewState.SEARCH_RESULTS
     reverseGeo = false
     this.searchResults = result
+    this.currentSearchIndex = 0
     mainViewController?.showSearchResults(result?.features)
     mainViewController?.hideProgress()
     mainViewController?.deactivateFindMeTracking()

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -58,8 +58,14 @@ class TestMainController : MainViewController {
     var isAttributionAboveSearchResults = false
     var isFindMeAboveSearchResults = false
     var currentSearchItemPosition = 0
+    var currentSearchIndex = 0
 
     override fun showSearchResults(features: List<Feature>?) {
+        searchResults = features
+    }
+
+    override fun showSearchResults(features: List<Feature>?, currentIndex: Int) {
+        currentSearchIndex = currentIndex
         searchResults = features
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -93,6 +93,15 @@ class MainPresenterTest {
         assertThat(mainController.isFindMeTrackingEnabled).isFalse()
     }
 
+    @Test fun onSearchResultsAvailable_shouldResetCurrentSearchIndex() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        result.features = features
+        presenter.currentSearchIndex = 3
+        presenter.onSearchResultsAvailable(result)
+        assertThat(presenter.currentSearchIndex).isEqualTo(0)
+    }
+
     @Test fun onReverseGeocodeResultsAvailable_shouldShowSearchResults() {
         val result = Result()
         val features = ArrayList<Feature>()

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -198,6 +198,19 @@ class MainPresenterTest {
         assertThat(newController.searchResults).isEqualTo(features)
     }
 
+    @Test fun onRestoreMapState_shouldRestorePreviousSearchResultsCurrentIndex() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        result.features = features
+        presenter.onSearchResultsAvailable(result)
+        presenter.currentSearchIndex = 2
+
+        val newController = TestMainController()
+        presenter.mainViewController = newController
+        presenter.onRestoreMapState()
+        assertThat(newController.currentSearchIndex).isEqualTo(2)
+    }
+
     @Test fun onRestoreMapState_shouldAdjustAttributionRoutePreview() {
         presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
         presenter.onRestoreMapState()
@@ -403,6 +416,30 @@ class MainPresenterTest {
 
         testPresenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
         assertThat(mainController.settingsApiTriggered).isTrue()
+    }
+
+    @Test fun onBackPressed_shouldRestoreSearchResultsSearchIndex() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        result.features = features
+        presenter.onSearchResultsAvailable(result)
+        presenter.currentSearchIndex = 2
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+
+        presenter.onBackPressed()
+        assertThat(mainController.currentSearchIndex).isEqualTo(2)
+    }
+
+    @Test fun onBackPressed_shouldRestoreSearchResults() {
+        val result = Result()
+        val features = ArrayList<Feature>()
+        result.features = features
+        presenter.onSearchResultsAvailable(result)
+        presenter.currentSearchIndex = 2
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+
+        presenter.onBackPressed()
+        assertThat(mainController.searchResults).isEqualTo(features)
     }
 
     @Test fun onBackPressed_shouldHideRoutePreview() {


### PR DESCRIPTION
This PR stores the search pager position in `MainPresenter` so that it can be used to restore the search results view when either the device is rotated or the user backs out of route preview mode. It also adds tests for this case.

I chose to leave the logic in `MainActivity` to keep the changes in this PR minimal and plan to move this code into the presenter in a separate PR as part of the ongoing test refactoring.

Closes #778 