### PR TITLE
Updates Android Gradle plugin to version 2.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.1'
+    classpath 'com.android.tools.build:gradle:2.2.2'
   }
 }
 


### PR DESCRIPTION
Initial testing reveals no build or runtime issues due to the upgrade.