### PR TITLE
Fix compass always visible

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -182,7 +182,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     private fun initMapRotateListener() {
-        mapzenMap?.setRotateResponder({ x, y, rotation -> presenter.onMapMotionEvent() })
+        mapzenMap?.setRotateResponder({ x, y, rotation -> presenter.onMapRotateEvent() })
     }
 
     override fun showCompass() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -185,6 +185,10 @@ class MainActivity : AppCompatActivity(), MainViewController,
         mapzenMap?.setRotateResponder({ x, y, rotation -> presenter.onMapMotionEvent() })
     }
 
+    override fun showCompass() {
+        compass.visibility = View.VISIBLE
+    }
+
     override fun rotateCompass() {
         val radians: Float = mapzenMap?.rotation as Float
         val degrees = Math.toDegrees(radians.toDouble()).toFloat()
@@ -318,6 +322,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     private fun initCompass() {
+        compass.visibility = View.GONE
         compass.setOnClickListener({
             presenter.onCompassClick()
         })

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -39,6 +39,7 @@ interface MainViewController {
     fun setMapRotation(radians: Float)
     fun drawRoute(route: Route)
     fun clearRoute()
+    fun showCompass()
     fun rotateCompass()
     fun reverseGeolocate(screenX: Float, screenY: Float)
     fun placeSearch(gid: String)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -49,7 +49,7 @@ interface MainPresenter {
     fun onCompassClick()
     fun getPeliasLocationProvider(): PeliasLocationProvider
     fun onReroute(location: ValhallaLocation)
-    fun onMapMotionEvent(): Boolean
+    fun onMapRotateEvent(): Boolean
     fun onReverseGeoRequested(screenX: Float?, screenY: Float?): Boolean
     fun onPlaceSearchRequested(gid: String): Boolean
     fun onExitNavigation()

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -560,7 +560,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     mainViewController?.setMapTilt(0f)
   }
 
-  override fun onMapMotionEvent(): Boolean {
+  override fun onMapRotateEvent(): Boolean {
     mainViewController?.showCompass()
     mainViewController?.rotateCompass()
     return false

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -561,6 +561,7 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
   }
 
   override fun onMapMotionEvent(): Boolean {
+    mainViewController?.showCompass()
     mainViewController?.rotateCompass()
     return false
   }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/CompassView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/CompassView.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import android.util.AttributeSet
 import com.mapzen.erasermap.R
 
-public class CompassView(context: Context, attrs: AttributeSet) : ButtonView(context, attrs) {
+class CompassView(context: Context, attrs: AttributeSet) : ButtonView(context, attrs) {
 
     override fun idForLayout():Int {
-        return R.layout.view_compass;
+        return R.layout.view_compass
     }
 
     override fun idForImage():Int {
-        return R.id.compass;
+        return R.id.compass
     }
 
     override fun setRotation(rotation: Float) {
@@ -21,9 +21,9 @@ public class CompassView(context: Context, attrs: AttributeSet) : ButtonView(con
         }
     }
 
-    public fun reset() {
+    fun reset() {
         val newRotation = if (image.rotation < 180) 0f else 360f
         image.animate().setDuration(1000).rotation(newRotation)
-        animate().setDuration(1000).alpha(0f).setStartDelay(1000)
+        animate().setDuration(1000).alpha(0f).startDelay = 1000
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/view/RouteModeView.kt
@@ -231,7 +231,6 @@ class RouteModeView : LinearLayout, RouteViewController, ViewPager.OnPageChangeL
 
     private fun onMapPan(deltaX: Float, deltaY: Float): Boolean {
         routePresenter.onMapPan(deltaX, deltaY)
-        mainPresenter?.onMapMotionEvent()
         return false
     }
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -62,6 +62,8 @@ class TestMainController : MainViewController {
     var toastifyResId = 0
     var focusSearchView = false
     var debugSettingsEnabled = false
+    var compassRotated = false
+    var compassShowing = false
 
     override fun showSearchResults(features: List<Feature>?) {
         searchResults = features
@@ -189,6 +191,11 @@ class TestMainController : MainViewController {
     }
 
     override fun rotateCompass() {
+        compassRotated = true
+    }
+
+    override fun showCompass() {
+        compassShowing = true
     }
 
     override fun reverseGeolocate(screenX: Float, screenY: Float) {

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -1158,6 +1158,16 @@ class MainPresenterTest {
         assertThat(mainController.zoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
     }
 
+    @Test fun onMapMotionEvent_shouldShowCompass() {
+        presenter.onMapMotionEvent()
+        assertThat(mainController.compassShowing)
+    }
+
+    @Test fun onMapMotionEvent_shouldRotateCompass() {
+        presenter.onMapMotionEvent()
+        assertThat(mainController.compassRotated)
+    }
+
     class RouteEventSubscriber {
         var event: RouteEvent? = null
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -1158,13 +1158,13 @@ class MainPresenterTest {
         assertThat(mainController.zoom).isEqualTo(MainPresenter.ROUTING_ZOOM)
     }
 
-    @Test fun onMapMotionEvent_shouldShowCompass() {
-        presenter.onMapMotionEvent()
+    @Test fun onMapRotateEvent_shouldShowCompass() {
+        presenter.onMapRotateEvent()
         assertThat(mainController.compassShowing)
     }
 
-    @Test fun onMapMotionEvent_shouldRotateCompass() {
-        presenter.onMapMotionEvent()
+    @Test fun onMapRotateEvent_shouldRotateCompass() {
+        presenter.onMapRotateEvent()
         assertThat(mainController.compassRotated)
     }
 


### PR DESCRIPTION
- Sets the compass to be hidden until the map is rotated
- Removes code that made the compass visible when the map was panned (now the compass will only be shown when the map is rotated)

Closes #776 