### PR TITLE
Restore map position and zoom for reverse geo back press

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -1272,4 +1272,12 @@ class MainActivity : AppCompatActivity(), MainViewController,
         val editText = searchController.searchView?.findViewById(R.id.search_src_text) as EditText?
         editText?.setSelection(editText.text.length)
     }
+
+    override fun getMapPosition(): LngLat? {
+        return mapzenMap?.position
+    }
+
+    override fun getMapZoom(): Float? {
+        return mapzenMap?.zoom
+    }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainViewController.kt
@@ -85,4 +85,6 @@ interface MainViewController {
     fun toastify(resId: Int)
     fun focusSearchView()
     fun toggleShowDebugSettings()
+    fun getMapPosition(): LngLat?
+    fun getMapZoom(): Float?
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenter.kt
@@ -27,6 +27,8 @@ interface MainPresenter {
     var reverseGeo: Boolean
     var reverseGeoLngLat: LngLat?
     var currentSearchIndex: Int
+    var mapPosition: LngLat?
+    var mapZoom: Float?
 
     fun onSearchResultsAvailable(result: Result?)
     fun onReverseGeocodeResultsAvailable(searchResults: Result?)

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -71,6 +71,8 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
       confidenceHandler.reverseGeoLngLat = value
     }
   override var currentSearchIndex: Int = 0
+  override var mapPosition: LngLat? = null
+  override var mapZoom: Float? = null
 
   private var searchResults: Result? = null
   private var destination: Feature? = null
@@ -315,6 +317,8 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     }
     reverseGeo = false
     destination = event.destination
+    mapPosition = mainViewController?.getMapPosition()
+    mapZoom = mainViewController?.getMapZoom()
     mainViewController?.collapseSearchView()
     mainViewController?.hideSearchResults()
     mainViewController?.hideReverseGeolocateResult()
@@ -391,6 +395,8 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     if (searchResults != null) {
       if (reverseGeo) {
         mainViewController?.showReverseGeocodeFeature(searchResults?.features)
+        mainViewController?.setMapPosition(mapPosition as LngLat, 0)
+        mainViewController?.setMapZoom(mapZoom as Float)
       } else {
         mainViewController?.showSearchResults(searchResults?.features, currentSearchIndex)
         var numFeatures = 0

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -395,8 +395,12 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
     if (searchResults != null) {
       if (reverseGeo) {
         mainViewController?.showReverseGeocodeFeature(searchResults?.features)
-        mainViewController?.setMapPosition(mapPosition as LngLat, 0)
-        mainViewController?.setMapZoom(mapZoom as Float)
+        if (mapPosition != null) {
+          mainViewController?.setMapPosition(mapPosition as LngLat, 0)
+        }
+        if (mapZoom != null) {
+          mainViewController?.setMapZoom(mapZoom as Float)
+        }
       } else {
         mainViewController?.showSearchResults(searchResults?.features, currentSearchIndex)
         var numFeatures = 0

--- a/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/controller/TestMainController.kt
@@ -368,4 +368,12 @@ class TestMainController : MainViewController {
     override fun toggleShowDebugSettings() {
         debugSettingsEnabled = !debugSettingsEnabled
     }
+
+    override fun getMapPosition(): LngLat? {
+        return lngLat
+    }
+
+    override fun getMapZoom(): Float? {
+        return zoom
+    }
 }

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -519,6 +519,27 @@ class MainPresenterTest {
         assertThat(mainController.routeLine).isNull()
     }
 
+    @Test fun onBackPressed_reverseGeo_shouldRestoreMapPosition() {
+        presenter.onSearchResultsAvailable(Result())
+        presenter.reverseGeo = true
+        mainController.lngLat = LngLat(40.0, 70.0)
+        mainController.zoom = 16f
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onBackPressed()
+        assertThat(mainController.lngLat?.latitude).isEqualTo(70.0)
+        assertThat(mainController.lngLat?.longitude).isEqualTo(40.0)
+    }
+
+    @Test fun onBackPressed_reverseGeo_shouldRestoreMapZoom() {
+        presenter.onSearchResultsAvailable(Result())
+        presenter.reverseGeo = true
+        mainController.lngLat = LngLat(40.0, 70.0)
+        mainController.zoom = 16f
+        presenter.onRoutePreviewEvent(RoutePreviewEvent(getTestFeature()))
+        presenter.onBackPressed()
+        assertThat(mainController.zoom).isEqualTo(16f)
+    }
+
     @Test fun onClickViewList_shouldMakeDirectionsVisible() {
         presenter.onClickViewList()
         assertThat(mainController.isDirectionListVisible).isTrue()


### PR DESCRIPTION
### Overview
Caches the map position and zoom when route preview is generated. When back is pressed for reverse geo requests, the presenter uses these values to restore the map to the previous position and zoom.

### Proposed Changes
Adds two new methods to `MainViewController` for retrieving the map zoom and position.

Closes #779 
