### PR TITLE
799 route preview orientation

### DIFF
--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -906,28 +906,28 @@ class MainActivity : AppCompatActivity(), MainViewController,
 
     private fun initRoutePreviewModeBtns() {
         byCar.setOnCheckedChangeListener { buttonView, isChecked ->
-            if (isChecked) {
+            if (buttonView.isPressed && isChecked) {
                 routeManager.type = Router.Type.DRIVING
                 route()
             }
         }
 
         byBike.setOnCheckedChangeListener { buttonView, isChecked ->
-            if (isChecked) {
+            if (buttonView.isPressed && isChecked) {
                 routeManager.type = Router.Type.BIKING
                 route()
             }
         }
 
         byFoot.setOnCheckedChangeListener { buttonView, isChecked ->
-            if (isChecked) {
+            if (buttonView.isPressed && isChecked) {
                 routeManager.type = Router.Type.WALKING
                 route()
             }
         }
 
         byTransit.setOnCheckedChangeListener { buttonView, isChecked ->
-            if (isChecked) {
+            if (buttonView.isPressed && isChecked) {
                 routeManager.type = Router.Type.MULTIMODAL
                 route()
             }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/event/RouteEvent.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/event/RouteEvent.kt
@@ -1,6 +1,0 @@
-package com.mapzen.erasermap.model.event
-
-/**
- * Published when the user begins routing to the destination.
- */
-class RouteEvent()

--- a/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/presenter/MainPresenterImpl.kt
@@ -19,7 +19,6 @@ import com.mapzen.erasermap.model.PermissionManager
 import com.mapzen.erasermap.model.RouteManager
 import com.mapzen.erasermap.model.event.LocationChangeEvent
 import com.mapzen.erasermap.model.event.RouteCancelEvent
-import com.mapzen.erasermap.model.event.RouteEvent
 import com.mapzen.erasermap.model.event.RoutePreviewEvent
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.DEFAULT
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTE_DIRECTION_LIST
@@ -577,7 +576,6 @@ open class MainPresenterImpl(val mapzenLocation: MapzenLocation, val bus: Bus,
       return
     }
 
-    bus.post(RouteEvent())
     mainViewController?.resetMute() //must call before generateRoutingMode()
     generateRoutingMode(true)
     vsm.viewState = ViewStateManager.ViewState.ROUTING

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/MainPresenterTest.kt
@@ -25,7 +25,6 @@ import com.mapzen.erasermap.model.TestRouteManager
 import com.mapzen.erasermap.model.ValhallaRouteManagerTest.TestRouteCallback
 import com.mapzen.erasermap.model.event.LocationChangeEvent
 import com.mapzen.erasermap.model.event.RouteCancelEvent
-import com.mapzen.erasermap.model.event.RouteEvent
 import com.mapzen.erasermap.model.event.RoutePreviewEvent
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.DEFAULT
 import com.mapzen.erasermap.presenter.ViewStateManager.ViewState.ROUTE_DIRECTION_LIST
@@ -799,13 +798,6 @@ class MainPresenterTest {
         assertThat(mainController.isRoutingModeVisible).isTrue()
     }
 
-    @Test fun onClickStartNavigation_shouldPublishRouteEvent() {
-        val subscriber = RouteEventSubscriber()
-        presenter.bus.register(subscriber)
-        presenter.onClickStartNavigation()
-        assertThat(subscriber.event).isNotNull()
-    }
-
     @Test fun onClickStartNavigation_shouldResetMute() {
         mainController.muted = true
         presenter.onClickStartNavigation()
@@ -1427,14 +1419,6 @@ class MainPresenterTest {
     @Test fun onMapRotateEvent_shouldRotateCompass() {
         presenter.onMapRotateEvent()
         assertThat(mainController.compassRotated)
-    }
-
-    class RouteEventSubscriber {
-        var event: RouteEvent? = null
-
-        @Subscribe fun onRouteEvent(event: RouteEvent) {
-            this.event = event
-        }
     }
 
     class ResolutionLocationSettingsChecker : LocationSettingsChecker {


### PR DESCRIPTION
### Overview
This PR updates the route preview button `setOnCheckedChangeListener` to consider whether the button has been pressed by the user before updating the route manager and routing

### Proposed Changes
This fixes a bug which, on orientation changes, caused the `setOnCheckedChangeListener` to be invoked which in turn caused the route preview view to show in routing mode

Closes #799 