### PR TITLE
Upgrade Mapzen Android SDK to version 1.2.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -125,7 +125,7 @@ dependencies {
   compile 'com.android.support:appcompat-v7:25.0.1'
   compile 'com.android.support:support-v4:25.0.1'
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  compile 'com.mapzen:mapzen-android-sdk:1.2.0'
+  compile 'com.mapzen:mapzen-android-sdk:1.2.1'
   compile "com.google.dagger:dagger:$dagger_version"
   compile 'com.squareup:otto:1.3.7'
   compile 'com.splunk.mint:mint:4.2.1'


### PR DESCRIPTION
### Overview

Upgrades Mapzen Android SDK to version 1.2.1 (includes Tangram 0.4.8)

### Proposed Changes

Resolves search result pin selection via Tangram core fix https://github.com/tangrams/tangram-es/pull/1185

Fixes #800 

