### PR TITLE
Upgrade Mapzen Android SDK

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-  ext.kotlin_version = '1.0.4'
+  ext.kotlin_version = '1.1.2'
   ext.dagger_version = '2.0'
   repositories {
     mavenCentral()
@@ -125,7 +125,7 @@ dependencies {
   compile 'com.android.support:appcompat-v7:25.1.0'
   compile 'com.android.support:support-v4:25.1.0'
   compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  compile 'com.mapzen:mapzen-android-sdk:1.3.0-SNAPSHOT'
+  compile 'com.mapzen:mapzen-android-sdk:1.4.0'
   compile "com.google.dagger:dagger:$dagger_version"
   compile 'com.squareup:otto:1.3.7'
   compile 'com.splunk.mint:mint:4.2.1'

--- a/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/controller/MainActivity.kt
@@ -254,7 +254,7 @@ class MainActivity : AppCompatActivity(), MainViewController,
     }
 
     private fun initMapzenMap() {
-        mapView.getMapAsync(apiKeys.apiKey, {
+        mapView.getMapAsync({
             this.mapzenMap = it
             configureMapzenMap()
             presenter.onRestoreMapState()

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ApiKeys.kt
@@ -1,5 +1,6 @@
 package com.mapzen.erasermap.model
 
+import com.mapzen.android.core.MapzenManager
 import com.mapzen.erasermap.BuildConfig
 import com.mapzen.erasermap.EraserMapApplication
 
@@ -24,6 +25,7 @@ class ApiKeys private constructor(val application: EraserMapApplication) {
     init {
         configureKeys()
         if (apiKey.isEmpty()) throw IllegalArgumentException("Api key cannot be empty.")
+        MapzenManager.instance(application).apiKey = apiKey
     }
 
     private fun configureKeys() {

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/Http.java
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/Http.java
@@ -3,4 +3,5 @@ package com.mapzen.erasermap.model;
 public interface Http {
   String HEADER_DNT = "DNT";
   String VALUE_HEADER_DNT = "1";
+  String PARAM_API_KEY = "api_key";
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/MapzenLocationImpl.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/MapzenLocationImpl.kt
@@ -29,14 +29,6 @@ public class MapzenLocationImpl(val locationClientManager: LocationClientManager
         override fun onLocationChanged(location: Location) {
             onLocationUpdate(location)
         }
-
-        override fun onProviderDisabled(provider: String) {
-
-        }
-
-        override fun onProviderEnabled(provider: String) {
-
-        }
     }
 
     private val request = LocationRequest.create()
@@ -60,7 +52,8 @@ public class MapzenLocationImpl(val locationClientManager: LocationClientManager
             LocationServices.FusedLocationApi?.setMockLocation(locationClient, settings.mockLocation)
         }
         if (settings.isMockRouteEnabled) {
-            LocationServices.FusedLocationApi?.setMockTrace(locationClient, settings.mockRoute)
+            LocationServices.FusedLocationApi?.setMockTrace(locationClient, settings.mockRoute?.path,
+                settings.mockRoute?.name)
         }
     }
 

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/TileHttpHandler.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/TileHttpHandler.kt
@@ -1,33 +1,16 @@
 package com.mapzen.erasermap.model
 
-import android.app.Application
-import android.os.Build
-import com.mapzen.tangram.HttpHandler
-import com.squareup.okhttp.Callback
+import okhttp3.Callback
 import java.io.File
 
-public class TileHttpHandler(application: Application) : HttpHandler() {
-    companion object {
-        @JvmStatic val KITKAT = 19
-    }
+class TileHttpHandler : TmpHttpHandler {
+    constructor() : super() {}
 
-    init {
-        if (Build.VERSION.SDK_INT >= KITKAT) {
-            val httpCache = File(application.externalCacheDir.absolutePath + "/tile_cache")
-            setCache(httpCache, 30 * 1024 * 1024)
-        }
-        okRequestBuilder.addHeader(Http.HEADER_DNT, Http.VALUE_HEADER_DNT)
-    }
+    constructor(cacheDir: File, cacheSize: Long) : super(cacheDir, cacheSize) {}
 
-    var apiKey: String? = null
-
-    override fun onRequest(url: String, callback: Callback): Boolean {
-        val urlWithApiKey = url + "?api_key=" + apiKey
-        return super.onRequest(urlWithApiKey, callback)
-    }
-
-    override fun onCancel(url: String) {
-        val urlWithApiKey = url + "?api_key=" + apiKey
-        super.onCancel(urlWithApiKey)
+    override fun onRequest(url: String, headers: Map<String, String>, callback: Callback): Boolean {
+        val emHeaders = mutableMapOf(Http.HEADER_DNT to Http.VALUE_HEADER_DNT)
+        emHeaders.putAll(headers)
+        return super.onRequest(url, emHeaders, callback)
     }
 }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/TmpHttpHandler.java
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/TmpHttpHandler.java
@@ -1,0 +1,182 @@
+package com.mapzen.erasermap.model;
+
+import com.mapzen.tangram.HttpHandler;
+
+import android.os.Build;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+import okhttp3.Cache;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.ConnectionSpec;
+import okhttp3.Headers;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.TlsVersion;
+
+/**
+ * Temporary TileHttpHandler super class until Tangram allows customizing headers.
+ */
+public class TmpHttpHandler extends HttpHandler {
+
+  private OkHttpClient okClient;
+
+  /**
+   * Enables TLS v1.2 when creating SSLSockets.
+   * <p/>
+   * For some reason, android supports TLS v1.2 from API 16, but enables it by
+   * default only from API 20.
+   *
+   * @link https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+   * @see SSLSocketFactory
+   */
+  private class Tls12SocketFactory extends SSLSocketFactory {
+    private final String[] TLS_V12_ONLY = {"TLSv1.2"};
+
+    final SSLSocketFactory delegate;
+
+    public Tls12SocketFactory(SSLSocketFactory base) {
+      this.delegate = base;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+      return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+      return delegate.getSupportedCipherSuites();
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws
+        IOException {
+      return patch(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException, UnknownHostException {
+      return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException, UnknownHostException {
+      return patch(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+      return patch(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+      return patch(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private Socket patch(Socket s) {
+      if (s instanceof SSLSocket) {
+        ((SSLSocket) s).setEnabledProtocols(TLS_V12_ONLY);
+      }
+      return s;
+    }
+  }
+
+  /**
+   * Construct an {@code HttpHandler} with default options.
+   */
+  public TmpHttpHandler() {
+    this(null, 0);
+  }
+
+  /**
+   * Construct an {@code HttpHandler} with cache.
+   * Cache map data in a directory with a specified size limit
+   * @param directory Directory in which map data will be cached
+   * @param maxSize Maximum size of data to cache, in bytes
+   */
+  public TmpHttpHandler(File directory, long maxSize) {
+    OkHttpClient.Builder builder = new OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .writeTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS);
+
+    if (directory != null && maxSize > 0) {
+      builder.cache(new Cache(directory, maxSize));
+    }
+
+    if (Build.VERSION.SDK_INT >= 16 && Build.VERSION.SDK_INT < 22) {
+      try {
+        SSLContext sc = SSLContext.getInstance("TLSv1.2");
+        sc.init(null, null, null);
+        builder.sslSocketFactory(new Tls12SocketFactory(sc.getSocketFactory()));
+
+        ConnectionSpec cs = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .tlsVersions(TlsVersion.TLS_1_2)
+            .build();
+
+        List<ConnectionSpec> specs = new ArrayList<>();
+        specs.add(cs);
+        specs.add(ConnectionSpec.COMPATIBLE_TLS);
+        specs.add(ConnectionSpec.CLEARTEXT);
+
+        builder.connectionSpecs(specs);
+      } catch (Exception exc) {
+        android.util.Log.e("Tangram", "Error while setting TLS 1.2", exc);
+      }
+    }
+
+    okClient = builder.build();
+  }
+
+  /**
+   * Begin an HTTP request
+   * @param url URL for the requested resource
+   * @param cb Callback for handling request result
+   * @return true if request was successfully started
+   */
+  public boolean onRequest(String url, Map<String, String> headers, Callback cb) {
+    Request request = new Request.Builder()
+        .url(url)
+        .headers(Headers.of(headers))
+        .build();
+    okClient.newCall(request).enqueue(cb);
+    return true;
+  }
+
+  /**
+   * Cancel an HTTP request
+   * @param url URL of the request to be cancelled
+   */
+  public void onCancel(String url) {
+
+    // check and cancel running call
+    for (Call runningCall : okClient.dispatcher().runningCalls()) {
+      if (runningCall.request().url().toString().equals(url)) {
+        runningCall.cancel();
+      }
+    }
+
+    // check and cancel queued call
+    for (Call queuedCall : okClient.dispatcher().queuedCalls()) {
+      if (queuedCall.request().url().toString().equals(url)) {
+        queuedCall.cancel();
+      }
+    }
+  }
+
+}

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaHttpHandler.java
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaHttpHandler.java
@@ -4,12 +4,15 @@ import com.mapzen.android.routing.TurnByTurnHttpHandler;
 
 import java.io.IOException;
 
+import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.logging.HttpLoggingInterceptor;
 
 public class ValhallaHttpHandler extends TurnByTurnHttpHandler {
+
+  private String apiKey = "";
 
   public ValhallaHttpHandler(String endpoint, HttpLoggingInterceptor.Level logLevel) {
     configure(endpoint, logLevel);
@@ -19,11 +22,21 @@ public class ValhallaHttpHandler extends TurnByTurnHttpHandler {
     configure(DEFAULT_URL, logLevel);
   }
 
+  public void setApiKey(String apiKey) {
+    this.apiKey = apiKey;
+  }
+
   @Override
   protected Response onRequest(Interceptor.Chain chain) throws IOException {
+    final HttpUrl url = chain.request()
+        .url()
+        .newBuilder()
+        .addQueryParameter(Http.PARAM_API_KEY, apiKey)
+        .build();
     final Request request = chain.request()
         .newBuilder()
         .addHeader(Http.HEADER_DNT, Http.VALUE_HEADER_DNT)
+        .url(url)
         .build();
     return chain.proceed(request);
   }

--- a/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
+++ b/app/src/main/kotlin/com/mapzen/erasermap/model/ValhallaRouteManager.kt
@@ -54,7 +54,7 @@ class ValhallaRouteManager(val settings: AppSettings,
             val router = getInitializedRouter(type)
 
             if (location.hasBearing()) {
-                router.setLocation(start, location.bearing)
+                router.setLocation(start, location.bearing.toInt())
             } else {
                 router.setLocation(start)
             }

--- a/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
+++ b/app/src/test/java/com/mapzen/erasermap/TestAndroidModule.java
@@ -83,9 +83,7 @@ public class TestAndroidModule {
     }
 
     @Provides @Singleton TileHttpHandler provideTileHttpHandler() {
-        TileHttpHandler handler = new TileHttpHandler(application);
-        handler.setApiKey(BuildConfig.API_KEY);
-        return handler;
+        return new TileHttpHandler();
     }
 
     @Provides @Singleton Bus provideBus() {

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ApiKeysTest.kt
@@ -1,16 +1,30 @@
 package com.mapzen.erasermap.model
 
+import com.mapzen.android.core.MapzenManager
 import com.mapzen.erasermap.BuildConfig
 import com.mapzen.erasermap.EraserMapApplication
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
 
+@PrepareForTest(MapzenManager::class)
+@RunWith(PowerMockRunner::class)
 class ApiKeysTest {
     val application = EraserMapApplication()
-    val apiKeys = ApiKeys.Companion.sharedInstance(application)
+    var apiKeys: ApiKeys? = null
+
+    @Before fun setup() {
+        PowerMockito.mockStatic(MapzenManager::class.java)
+        PowerMockito.`when`(MapzenManager.instance(application)).thenReturn(Mockito.mock(
+            MapzenManager::class.java))
+        apiKeys = ApiKeys.Companion.sharedInstance(application)
+    }
 
     @Test fun shouldNotBeNull() {
         assertThat(apiKeys).isNotNull()

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/LostClientManagerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/LostClientManagerTest.kt
@@ -69,6 +69,8 @@ class LostClientManagerTest {
       return connected
     }
 
+    override fun unregisterConnectionCallbacks(callbacks: LostApiClient.ConnectionCallbacks?) {
+    }
   }
   class TestRunnable: Runnable {
 

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouter.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/TestRouter.kt
@@ -9,7 +9,7 @@ class TestRouter(context: Context) : MapzenRouter(context) {
     var locations: ArrayList<DoubleArray> = ArrayList()
     var isFetching: Boolean = false
     var units: MapzenRouter.DistanceUnits = MapzenRouter.DistanceUnits.MILES
-    var bearing: Float = 0f
+    var bearing: Int = 0
     var name: String? = null
 
     override fun clearLocations(): MapzenRouter {
@@ -38,7 +38,7 @@ class TestRouter(context: Context) : MapzenRouter(context) {
         return this
     }
 
-    override fun setLocation(point: DoubleArray, heading: Float): MapzenRouter {
+    override fun setLocation(point: DoubleArray, heading: Int): MapzenRouter {
         locations.add(point)
         bearing = heading
         return this

--- a/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/model/ValhallaRouteManagerTest.kt
@@ -2,6 +2,7 @@ package com.mapzen.erasermap.model
 
 import android.content.Context
 import android.content.res.Resources
+import com.mapzen.android.core.MapzenManager
 import com.mapzen.erasermap.dummy.TestHelper.getTestFeature
 import com.mapzen.erasermap.dummy.TestHelper.getTestLocation
 import com.mapzen.valhalla.Route
@@ -9,8 +10,16 @@ import com.mapzen.valhalla.RouteCallback
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito
+import org.powermock.api.mockito.PowerMockito
+import org.powermock.core.classloader.annotations.PowerMockIgnore
+import org.powermock.core.classloader.annotations.PrepareForTest
+import org.powermock.modules.junit4.PowerMockRunner
 
+@PrepareForTest(MapzenManager::class)
+@RunWith(PowerMockRunner::class)
+@PowerMockIgnore("javax.net.ssl.*")
 class ValhallaRouteManagerTest {
     val routerFactory = TestRouterFactory()
     var routeManager: ValhallaRouteManager? = null
@@ -24,6 +33,9 @@ class ValhallaRouteManagerTest {
         Mockito.`when`(context.applicationContext).thenReturn(context)
         Mockito.`when`(resources.getIdentifier("turn_by_turn_key", "string", "test")).thenReturn(1)
         Mockito.`when`(resources.getString(1)).thenThrow(Resources.NotFoundException::class.java)
+        PowerMockito.mockStatic(MapzenManager::class.java)
+        PowerMockito.`when`(MapzenManager.instance(context)).thenReturn(Mockito.mock(
+            MapzenManager::class.java))
         routeManager = ValhallaRouteManager(TestAppSettings(), routerFactory, context)
         router = routerFactory.getRouter(context) as TestRouter
     }

--- a/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
+++ b/app/src/test/kotlin/com/mapzen/erasermap/presenter/RoutePresenterTest.kt
@@ -7,7 +7,6 @@ import com.mapzen.erasermap.view.MapListToggleButton
 import com.mapzen.erasermap.view.TestRouteController
 import com.mapzen.helpers.RouteEngine
 import com.mapzen.model.ValhallaLocation
-import com.mapzen.tangram.LngLat
 import com.mapzen.valhalla.Route
 import com.squareup.otto.Bus
 import com.squareup.otto.Subscribe

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.3'
+    classpath 'com.android.tools.build:gradle:2.3.3'
   }
 }
 

--- a/circle.yml
+++ b/circle.yml
@@ -22,7 +22,7 @@ test:
         parallel: true
   post:
     - mkdir -p $CIRCLE_TEST_REPORTS/junit
-    - cp app/build/test-results/devDebug/*.xml $CIRCLE_TEST_REPORTS/junit
+    - cp app/build/test-results/testDevDebugUnitTest/*.xml $CIRCLE_TEST_REPORTS/junit
 
 deployment:
   all:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Oct 14 10:23:34 MDT 2016
+#Mon Jun 19 15:29:55 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
### Overview
Upgrades EM to the latest release of the Mapzen Android SDK (1.4.0)

### Proposed Changes
- Upgrades to Kotlin 1.1.2
- Upgrades to Gradle 2.3.3
- Creates temporary `TileHttpHandler` superclass `TmpHttpHandler` to allow for customizing headers in tile requests. This class will be removed and `TileHttpHandler` will be updated to inherit from Tangram class when dependent work is completed (https://github.com/mapzen/eraser-map/issues/821)

Closes #816 