### PR TITLE
Bump Min SDK to 19/4.4/kitkat

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ android {
 
   defaultConfig {
     applicationId "com.mapzen.erasermap"
-    minSdkVersion 15
+    minSdkVersion 19
     targetSdkVersion 25
     versionCode buildVersionCode()
     versionName version


### PR DESCRIPTION
### Overview
Bumps min version to KitKat

### Proposed Changes
Drops support for ~9% of devices running SDKs older than we want to support

Closes #819 